### PR TITLE
Add undo functionality for annotations

### DIFF
--- a/src/frontend2/index.html
+++ b/src/frontend2/index.html
@@ -13,9 +13,12 @@
 			<div id='image-container'></div>
 		</div>
 		
-		<!-- Right Panel: Controls -->
-		<div class="right-panel"></div>
-		<script type="module" src="js/app.js"></script>
+                <!-- Right Panel: Controls -->
+                <div class="right-panel">
+                        <button id="undo-btn" class="undo-btn">Undo</button>
+                        <div id="class-manager"></div>
+                </div>
+                <script type="module" src="js/app.js"></script>
 </body>
 
 </html>

--- a/src/frontend2/js/api.js
+++ b/src/frontend2/js/api.js
@@ -10,9 +10,11 @@ export class API {
         const res = await fetch(url);
         if (!res.ok) throw new Error('No images available');
         const filename = res.headers.get('X-Image-Id') || res.headers.get('X-Filename');
+        const labelClass = res.headers.get('X-Label-Class');
+        const labelSource = res.headers.get('X-Label-Source');
         const blob = await res.blob();
         const imageUrl = URL.createObjectURL(blob);
-        return { imageUrl, filename };
+        return { imageUrl, filename, labelClass, labelSource };
     }
 
     // Annotate a sample (returns JSON status)
@@ -24,6 +26,29 @@ export class API {
         });
         if (!res.ok) throw new Error('Annotation failed');
         return await res.json();
+    }
+
+    // Delete annotation for a sample
+    async deleteAnnotation(filepath) {
+        const res = await fetch('/annotate', {
+            method: 'DELETE',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ filepath })
+        });
+        if (!res.ok) throw new Error('Delete failed');
+        return await res.json();
+    }
+
+    // Load specific sample by id
+    async loadSample(id) {
+        const res = await fetch(`/sample?id=${encodeURIComponent(id)}`);
+        if (!res.ok) throw new Error('Sample not found');
+        const filename = res.headers.get('X-Image-Id') || res.headers.get('X-Filename');
+        const labelClass = res.headers.get('X-Label-Class');
+        const labelSource = res.headers.get('X-Label-Source');
+        const blob = await res.blob();
+        const imageUrl = URL.createObjectURL(blob);
+        return { imageUrl, filename, labelClass, labelSource };
     }
 
     // Get config

--- a/src/frontend2/js/classManager.js
+++ b/src/frontend2/js/classManager.js
@@ -62,9 +62,13 @@ export class ClassManager {
     }
 
     // Setters for state
-    setCurrentImageFilename(filename) {
+    setCurrentImageFilename(filename, selectedClass = null) {
         this.currentImageFilename = filename;
-        this.selectedClass = null;
+        this.selectedClass = selectedClass;
+        this.render();
+    }
+    setSelectedClass(className) {
+        this.selectedClass = className;
         this.render();
     }
     setGlobalClasses(classes) {

--- a/src/frontend2/js/undoManager.js
+++ b/src/frontend2/js/undoManager.js
@@ -1,0 +1,35 @@
+export class UndoManager {
+    constructor(api, viewer, classManager) {
+        this.api = api;
+        this.viewer = viewer;
+        this.classManager = classManager;
+        this.history = [];
+    }
+
+    record(imageId) {
+        if (imageId) {
+            this.history.push(imageId);
+        }
+    }
+
+    async undo() {
+        if (this.history.length === 0) {
+            alert('No more actions to undo');
+            return;
+        }
+        const id = this.history.pop();
+        try {
+            await this.api.deleteAnnotation(id);
+        } catch (e) {
+            console.error('Failed to delete annotation:', e);
+        }
+        try {
+            const { imageUrl, filename, labelClass, labelSource } = await this.api.loadSample(id);
+            this.viewer.loadImage(imageUrl, filename);
+            const cls = labelSource === 'annotation' ? labelClass : null;
+            this.classManager.setCurrentImageFilename(filename, cls);
+        } catch (e) {
+            console.error('Failed to load sample:', e);
+        }
+    }
+}

--- a/src/frontend2/style.css
+++ b/src/frontend2/style.css
@@ -115,9 +115,19 @@ body {
 }
 
 .class-btn.selected {
-	background: #b3e5fc;
-	border-color: #0288d1;
-	border-width: 2px;
+        background: #b3e5fc;
+        border-color: #0288d1;
+        border-width: 2px;
+}
+
+.undo-btn {
+        padding: 8px 12px;
+        border: 1px solid #ffc107;
+        background: #ffc107;
+        color: black;
+        border-radius: 4px;
+        cursor: pointer;
+        margin-bottom: 10px;
 }
 
 .info-display {


### PR DESCRIPTION
## Summary
- add Undo button to new frontend
- implement UndoManager to track and revert annotations
- extend API utility with sample loading and delete annotation
- support pre-selected class when loading images
- update app initialization to wire up undo
- include basic styling for Undo button

## Testing
- `python -m py_compile src/backend/main.py src/database/data.py src/database/db_init.py`

------
https://chatgpt.com/codex/tasks/task_e_688baa0f39b4832fb4daeace6ec828e8