### PR TITLE
Implement active learning strategy for /next

### DIFF
--- a/src/database/data.py
+++ b/src/database/data.py
@@ -519,6 +519,14 @@ class DatabaseAPI:
     def close(self):
         self.conn.close()
 
+    def get_annotation_counts(self):
+        """Return a dict mapping label class to number of annotations."""
+        cursor = self.conn.cursor()
+        cursor.execute(
+            "SELECT class, COUNT(*) FROM annotations WHERE type='label' GROUP BY class"
+        )
+        return {row[0]: row[1] for row in cursor.fetchall()}
+
     def delete_label_annotation(self, filepath):
         """
         Delete the 'label' annotation for the given image filepath, if it exists.


### PR DESCRIPTION
## Summary
- add `get_annotation_counts` helper in database API
- implement active-learning logic in `/next` endpoint
- keep sequential strategy via `strategy=sequential`

## Testing
- `python -m py_compile src/backend/main.py src/database/data.py`

------
https://chatgpt.com/codex/tasks/task_e_688babcd2720832fb606fd6d6ff04117