### PR TITLE
Add stats endpoint and frontend progress display

### DIFF
--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -25,6 +25,9 @@ db.set_samples([s["filepath"] for s in db_dict["samples"]])
 # In-memory accuracy stats
 accuracy_stats = {"tries": 0, "correct": 0}
 
+# Track the last image served to the client
+last_image_served = None
+
 
 def create_image_response(image_path):
     """Helper function to create image response with headers"""
@@ -51,6 +54,9 @@ def create_image_response(image_path):
             headers["X-Label-Source"] = "prediction"
             headers["X-Label-Probability"] = str(pred_ann.get('probability', ''))
     
+    global last_image_served
+    last_image_served = str(image_path)
+
     return FileResponse(image_path, media_type=mime_type, headers=headers)
 
 
@@ -174,8 +180,15 @@ async def get_config(request: Request):
     return JSONResponse(config)
 
 async def get_stats(request: Request):
-    # Return the accuracy stats
-    return JSONResponse(accuracy_stats)
+    annotated = db.count_labeled_samples()
+    total = db.count_total_samples()
+    return JSONResponse(
+        {
+            "image": last_image_served,
+            "annotated": annotated,
+            "total": total,
+        }
+    )
 
 app = Starlette(
     routes=[

--- a/src/database/data.py
+++ b/src/database/data.py
@@ -542,3 +542,19 @@ class DatabaseAPI:
             (sample_id,)
         )
         self.conn.commit()
+
+    def count_labeled_samples(self):
+        """Return the number of unique samples that have a label annotation."""
+        cursor = self.conn.cursor()
+        cursor.execute(
+            "SELECT COUNT(DISTINCT sample_id) FROM annotations WHERE type='label'"
+        )
+        row = cursor.fetchone()
+        return row[0] if row else 0
+
+    def count_total_samples(self):
+        """Return the total number of samples in the database."""
+        cursor = self.conn.cursor()
+        cursor.execute("SELECT COUNT(*) FROM samples")
+        row = cursor.fetchone()
+        return row[0] if row else 0

--- a/src/frontend2/index.html
+++ b/src/frontend2/index.html
@@ -16,6 +16,7 @@
                 <!-- Right Panel: Controls -->
                 <div class="right-panel">
                         <button id="undo-btn" class="undo-btn">Undo</button>
+                        <div id="stats-display" class="info-display"></div>
                         <div id="class-manager"></div>
                 </div>
                 <script type="module" src="js/app.js"></script>

--- a/src/frontend2/js/app.js
+++ b/src/frontend2/js/app.js
@@ -8,6 +8,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         const leftPanel = document.querySelector('.left-panel');
         const classPanel = document.querySelector('#class-manager');
         const undoBtn = document.getElementById('undo-btn');
+        const statsDiv = document.getElementById('stats-display');
         if (!leftPanel) {
                 console.error('Left panel container not found.');
                 return;
@@ -17,8 +18,20 @@ document.addEventListener('DOMContentLoaded', async () => {
                 return;
         }
 
-	// Create the API instance
+        // Create the API instance
         const api = new API();
+
+        async function updateStats() {
+                if (!statsDiv) return;
+                try {
+                        const stats = await api.getStats();
+                        if (stats && stats.image) {
+                                statsDiv.textContent = `${stats.image} (${stats.annotated}/${stats.total})`;
+                        }
+                } catch (e) {
+                        console.error('Failed to fetch stats:', e);
+                }
+        }
 
 	// Create the viewer instance
 	const viewer = new ImageViewer(leftPanel, 'loading-overlay', 'c');
@@ -31,6 +44,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                         viewer.loadImage(imageUrl, filename);
                         const annClass = labelSource === 'annotation' ? labelClass : null;
                         classManager.setCurrentImageFilename(filename, annClass);
+                        await updateStats();
                 } catch (e) {
                         console.error('Failed to fetch next image:', e);
                 }
@@ -52,6 +66,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 viewer.loadImage(imageUrl, filename);
                 const annClass = labelSource === 'annotation' ? labelClass : null;
                 classManager.setCurrentImageFilename(filename, annClass);
+                await updateStats();
         } catch (e) {
                 console.error('Failed to fetch first image:', e);
                 return;

--- a/src/frontend2/style.css
+++ b/src/frontend2/style.css
@@ -131,8 +131,12 @@ body {
 }
 
 .info-display {
-	font-size: 14px;
-	line-height: 1.4;
+        font-size: 14px;
+        line-height: 1.4;
+}
+
+#stats-display {
+        margin-bottom: 10px;
 }
 
 .info-display b {


### PR DESCRIPTION
## Summary
- add DB helper methods for counting annotated/total samples
- track last served image on the backend and expose via `/stats`
- show annotation progress in the frontend

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688bf1c0a7d0832f94d2c06ecc1588ac