### PR TITLE
Persist config in DB

### DIFF
--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -21,6 +21,7 @@ validate_db_dict(db_dict)
 # Initialize the database
 db = DatabaseAPI()
 db.set_samples([s["filepath"] for s in db_dict["samples"]])
+config = db.get_config() or {}
 
 # In-memory accuracy stats
 accuracy_stats = {"tries": 0, "correct": 0}
@@ -154,24 +155,24 @@ async def get_accuracy_stats(request: Request):
         "accuracy": accuracy
     })
 
-config = dict()
-
 async def put_config(request: Request):
     data = await request.json()
     if not isinstance(data, dict):
         return JSONResponse({"error": "Invalid config format"}, status_code=400)
     
-    # Validate and save the config
+    # Merge and save the config in the database
     config.update(data)
+    db.update_config(config)
     print("Config updated:", config)
     return JSONResponse({"status": "Config saved successfully"})
 
 async def get_config(request: Request):
-    if not config:
+    cfg = db.get_config()
+    if not cfg:
         return JSONResponse({"error": "No config set"}, status_code=404)
-    
-    print("Config updated", config)
-    return JSONResponse(config)
+
+    print("Config updated", cfg)
+    return JSONResponse(cfg)
 
 async def get_stats(request: Request):
     # Return the accuracy stats

--- a/src/database/data.py
+++ b/src/database/data.py
@@ -219,6 +219,7 @@ predictions: id, sample_id, sample_filepath, type (label/bbox), class, coordinat
 
 import os
 import sqlite3
+import json
 
 
 class DatabaseAPI:
@@ -499,20 +500,28 @@ class DatabaseAPI:
         )
         cursor.execute(
             """
-			CREATE TABLE IF NOT EXISTS predictions (
-				id INTEGER PRIMARY KEY AUTOINCREMENT,
-				sample_id INTEGER NOT NULL,
-				sample_filepath TEXT,
-				type TEXT,
-				class TEXT,
-				probability REAL,
-				x INTEGER,
-				y INTEGER,
-				width INTEGER,
-				height INTEGER,
-				FOREIGN KEY(sample_id) REFERENCES samples(id)
-			)
-		"""
+                        CREATE TABLE IF NOT EXISTS predictions (
+                                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                                sample_id INTEGER NOT NULL,
+                                sample_filepath TEXT,
+                                type TEXT,
+                                class TEXT,
+                                probability REAL,
+                                x INTEGER,
+                                y INTEGER,
+                                width INTEGER,
+                                height INTEGER,
+                                FOREIGN KEY(sample_id) REFERENCES samples(id)
+                        )
+                """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS config (
+                architecture TEXT,
+                classes TEXT
+            )
+            """
         )
         self.conn.commit()
 
@@ -542,3 +551,36 @@ class DatabaseAPI:
             (sample_id,)
         )
         self.conn.commit()
+
+    def get_config(self):
+        """Return the configuration as a dict or empty dict if not set."""
+        cursor = self.conn.cursor()
+        cursor.execute("SELECT architecture, classes FROM config LIMIT 1")
+        row = cursor.fetchone()
+        if not row:
+            return {}
+        architecture, classes_json = row
+        classes = json.loads(classes_json) if classes_json else []
+        return {"architecture": architecture, "classes": classes}
+
+    def update_config(self, config):
+        """Merge and persist the provided config dict."""
+        current = self.get_config()
+        current.update(config)
+        architecture = current.get("architecture")
+        classes_json = json.dumps(current.get("classes", []))
+        cursor = self.conn.cursor()
+        cursor.execute("SELECT COUNT(*) FROM config")
+        exists = cursor.fetchone()[0] > 0
+        if exists:
+            cursor.execute(
+                "UPDATE config SET architecture = ?, classes = ?",
+                (architecture, classes_json),
+            )
+        else:
+            cursor.execute(
+                "INSERT INTO config (architecture, classes) VALUES (?, ?)",
+                (architecture, classes_json),
+            )
+        self.conn.commit()
+        return current


### PR DESCRIPTION
## Summary
- add config table to the SQLite database
- persist configuration to database via DatabaseAPI
- expose config persistence in backend endpoints

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688bf2595560832fa5f365b5e398e6fb