### PR TITLE
Fix class list persistence on refresh

### DIFF
--- a/src/frontend2/js/app.js
+++ b/src/frontend2/js/app.js
@@ -43,7 +43,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                         const { imageUrl, filename, labelClass, labelSource } = await api.loadNextImage(currentId);
                         viewer.loadImage(imageUrl, filename);
                         const annClass = labelSource === 'annotation' ? labelClass : null;
-                        classManager.setCurrentImageFilename(filename, annClass);
+                        await classManager.setCurrentImageFilename(filename, annClass);
                         await updateStats();
                 } catch (e) {
                         console.error('Failed to fetch next image:', e);
@@ -65,7 +65,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 const { imageUrl, filename, labelClass, labelSource } = await api.loadNextImage();
                 viewer.loadImage(imageUrl, filename);
                 const annClass = labelSource === 'annotation' ? labelClass : null;
-                classManager.setCurrentImageFilename(filename, annClass);
+                await classManager.setCurrentImageFilename(filename, annClass);
                 await updateStats();
         } catch (e) {
                 console.error('Failed to fetch first image:', e);

--- a/src/frontend2/js/classManager.js
+++ b/src/frontend2/js/classManager.js
@@ -26,6 +26,9 @@ export class ClassManager {
 
         this.render();
 
+        // Load any persisted classes from the backend
+        this.loadClassesFromConfig();
+
         // Keyboard shortcuts for class selection
         document.addEventListener('keydown', (e) => {
             // Only trigger if not typing in an input/textarea
@@ -61,10 +64,24 @@ export class ClassManager {
         });
     }
 
+    // Load class list from server config
+    async loadClassesFromConfig() {
+        if (!this.api || typeof this.api.getConfig !== 'function') return;
+        try {
+            const cfg = await this.api.getConfig();
+            if (cfg && Array.isArray(cfg.classes)) {
+                this.globalClasses = cfg.classes;
+            }
+        } catch (e) {
+            console.error('Failed to load classes from config:', e);
+        }
+    }
+
     // Setters for state
-    setCurrentImageFilename(filename, selectedClass = null) {
+    async setCurrentImageFilename(filename, selectedClass = null) {
         this.currentImageFilename = filename;
         this.selectedClass = selectedClass;
+        await this.loadClassesFromConfig();
         this.render();
     }
     setSelectedClass(className) {

--- a/src/frontend2/js/undoManager.js
+++ b/src/frontend2/js/undoManager.js
@@ -36,7 +36,7 @@ export class UndoManager {
             const { imageUrl, filename, labelClass, labelSource } = await this.api.loadSample(id);
             this.viewer.loadImage(imageUrl, filename);
             const cls = labelSource === 'annotation' ? labelClass : null;
-            this.classManager.setCurrentImageFilename(filename, cls);
+            await this.classManager.setCurrentImageFilename(filename, cls);
         } catch (e) {
             console.error('Failed to load sample:', e);
         }


### PR DESCRIPTION
## Summary
- keep class list persistent by loading `/config` whenever a new image loads
- update ClassManager to fetch classes from the backend
- await new async method when switching images or undoing

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688c8e59ede0832fb9f4c9ca14e059ea