### PR TITLE
Show model performance in stats

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -10,9 +10,11 @@ A human-in-the-loop image annotation system with continuous training.
   - `GET /sample?id=ID` serves an image by ID with the same headers.
   - `POST /annotate` stores `{filepath, class}` (and optional bbox/point info).
   - `DELETE /annotate` removes the label annotation for a filepath.
-  - `GET /stats` reports accuracy from accepted predictions.
+  - `GET /stats` reports image counts, per-class annotation counts, and
+    model performance metrics including tries, correct counts, accuracy
+    and error rate.
 - **DatabaseAPI** (`src/database/data.py`)
-  - SQLite tables: `samples(filepath)`, `annotations(id, sample_id, sample_filepath, type, class, x, y, width, height, timestamp)`, `predictions(id, sample_id, sample_filepath, type, class, probability, x, y, width, height)`, `config(architecture, classes)`.
+  - SQLite tables: `samples(filepath)`, `annotations(id, sample_id, sample_filepath, type, class, x, y, width, height, timestamp)`, `predictions(id, sample_id, sample_filepath, type, class, probability, x, y, width, height)`, `config(architecture, classes)`, `accuracy_stats(tries, correct)`.
   - Methods to set/get samples, annotations, predictions and export DB to JSON.
   - TODO: helper to fetch the next unlabeled sample.
 

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -23,9 +23,6 @@ db = DatabaseAPI()
 db.set_samples([s["filepath"] for s in db_dict["samples"]])
 config = db.get_config() or {}
 
-# In-memory accuracy stats
-accuracy_stats = {"tries": 0, "correct": 0}
-
 # Track the last image served to the client
 last_image_served = None
 
@@ -141,9 +138,8 @@ async def handle_annotation(request: Request):
         preds = db.get_predictions(filepath)
         pred_ann = next((p for p in preds if p.get('type') == 'label' and p.get('probability') is not None), None)
         if pred_ann:
-            accuracy_stats["tries"] += 1
-            if str(pred_ann.get("class")) == str(class_name):
-                accuracy_stats["correct"] += 1
+            was_correct = str(pred_ann.get("class")) == str(class_name)
+            db.increment_accuracy(was_correct)
         return JSONResponse({"status": "ok"})
     elif request.method == "DELETE":
         data = await request.json()
@@ -156,8 +152,9 @@ async def handle_annotation(request: Request):
         return JSONResponse({"error": "Method not allowed"}, status_code=405)
 
 async def get_accuracy_stats(request: Request):
-    tries = accuracy_stats["tries"]
-    correct = accuracy_stats["correct"]
+    stats = db.get_accuracy_counts()
+    tries = stats["tries"]
+    correct = stats["correct"]
     accuracy = (correct / tries) if tries > 0 else None
     return JSONResponse({
         "tries": tries,
@@ -187,11 +184,22 @@ async def get_config(request: Request):
 async def get_stats(request: Request):
     annotated = db.count_labeled_samples()
     total = db.count_total_samples()
+    class_counts = db.get_annotation_counts()
+    stats = db.get_accuracy_counts()
+    tries = stats["tries"]
+    correct = stats["correct"]
+    accuracy = (correct / tries) if tries > 0 else None
+    error = (1 - accuracy) if accuracy is not None else None
     return JSONResponse(
         {
             "image": last_image_served,
             "annotated": annotated,
             "total": total,
+            "class_counts": class_counts,
+            "tries": tries,
+            "correct": correct,
+            "accuracy": accuracy,
+            "error": error,
         }
     )
 

--- a/src/frontend2/js/app.js
+++ b/src/frontend2/js/app.js
@@ -25,8 +25,25 @@ document.addEventListener('DOMContentLoaded', async () => {
                 if (!statsDiv) return;
                 try {
                         const stats = await api.getStats();
-                        if (stats && stats.image) {
-                                statsDiv.textContent = `${stats.image} (${stats.annotated}/${stats.total})`;
+                        if (stats) {
+                                const lines = [];
+                                if (stats.image) {
+                                        lines.push(`Image: ${stats.image}`);
+                                }
+                                lines.push(`Annotated: ${stats.annotated}/${stats.total}`);
+                                if (stats.class_counts) {
+                                        const pairs = Object.entries(stats.class_counts).map(([c, n]) => `${c}:${n}`);
+                                        lines.push(`Class counts: ${pairs.join(', ')}`);
+                                }
+                                lines.push(`Tries: ${stats.tries} Correct: ${stats.correct}`);
+                                let pct;
+                                if (typeof stats.accuracy === 'number') {
+                                        pct = (stats.accuracy * 100).toFixed(1);
+                                } else {
+                                        pct = '0';
+                                }
+                                lines.push(`Accuracy: <span class="accuracy-badge">${pct}%</span>`);
+                                statsDiv.innerHTML = lines.join('<br>');
                         }
                 } catch (e) {
                         console.error('Failed to fetch stats:', e);


### PR DESCRIPTION
## Summary
- track annotation correctness in the database
- persist accuracy counts via new `accuracy_stats` table
- expose updated metrics via `/stats`
- display accuracy percentage in the frontend stats panel
- show stats panel even when counts are zero
- label the accuracy metric and list class counts with tries/correct numbers

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688c9ebbc6b0832fb3142d1fa2c1906a