### PR TITLE
Improve stats endpoint and display

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -10,8 +10,8 @@ A human-in-the-loop image annotation system with continuous training.
   - `GET /sample?id=ID` serves an image by ID with the same headers.
   - `POST /annotate` stores `{filepath, class}` (and optional bbox/point info).
   - `DELETE /annotate` removes the label annotation for a filepath.
-  - `GET /stats` reports image counts and model performance metrics,
-    including accuracy and error rates.
+  - `GET /stats` reports image counts, annotations per class and model
+    performance metrics such as accuracy and error rates.
 - **DatabaseAPI** (`src/database/data.py`)
   - SQLite tables: `samples(filepath)`, `annotations(id, sample_id, sample_filepath, type, class, x, y, width, height, timestamp)`, `predictions(id, sample_id, sample_filepath, type, class, probability, x, y, width, height)`, `config(architecture, classes)`, `accuracy_stats(tries, correct)`.
   - Methods to set/get samples, annotations, predictions and export DB to JSON.

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -150,6 +150,7 @@ async def get_config(request: Request):
 async def get_stats(request: Request):
     annotated = db.count_labeled_samples()
     total = db.count_total_samples()
+    ann_counts = db.get_annotation_counts()
     stats = db.get_accuracy_counts()
     tries = stats["tries"]
     correct = stats["correct"]
@@ -164,6 +165,7 @@ async def get_stats(request: Request):
             "correct": correct,
             "accuracy": accuracy,
             "error": error,
+            "annotation_counts": ann_counts,
         }
     )
 

--- a/src/frontend2/js/app.js
+++ b/src/frontend2/js/app.js
@@ -26,18 +26,30 @@ document.addEventListener('DOMContentLoaded', async () => {
                 try {
                         const stats = await api.getStats();
                         if (stats) {
-                                let text = '';
+                                let html = '';
                                 if (stats.image) {
-                                        text += `${stats.image} `;
+                                        html += `<div><b>Last image:</b> ${stats.image}</div>`;
                                 }
-                                text += `(${stats.annotated}/${stats.total})`;
+                                html += `<div><b>Annotated:</b> ${stats.annotated}/${stats.total}</div>`;
+
+                                if (stats.annotation_counts) {
+                                        const counts = Object.entries(stats.annotation_counts)
+                                                .map(([cls, n]) => `<div>${cls}: ${n}</div>`) 
+                                                .join('');
+                                        html += `<div><b>Annotations per class:</b>${counts}</div>`;
+                                }
+
+                                html += `<div><b>Tries:</b> ${stats.tries}</div>`;
+                                html += `<div><b>Correct:</b> ${stats.correct}</div>`;
+
                                 if (typeof stats.accuracy === 'number') {
                                         const pct = (stats.accuracy * 100).toFixed(1);
-                                        text += ` <span class="accuracy-badge">${pct}%</span>`;
-                                } else if (stats.tries === 0) {
-                                        text += ' <span class="accuracy-badge">0%</span>';
+                                        html += `<div><b>Accuracy:</b> <span class="accuracy-badge">${pct}%</span></div>`;
+                                } else {
+                                        html += `<div><b>Accuracy:</b> <span class="accuracy-badge">0%</span></div>`;
                                 }
-                                statsDiv.innerHTML = text;
+
+                                statsDiv.innerHTML = html;
                         }
                 } catch (e) {
                         console.error('Failed to fetch stats:', e);


### PR DESCRIPTION
## Summary
- include annotation counts in `/stats` endpoint
- show detailed stats in frontend: per-class counts, tries, correct and accuracy
- document stats endpoint in specification

## Testing
- `python -m py_compile src/backend/main.py`
- `python -m py_compile src/database/data.py`
- `node --check src/frontend2/js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_688cb024b8f0832faa6027c9f26ee821