### PR TITLE
Add frontend strategy selection

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -6,7 +6,9 @@ A human-in-the-loop image annotation system with continuous training.
 - **Framework**: Starlette.
 - **Endpoints**
   - `PUT /config` and `GET /config` manage architecture, class list and preprocessing.
-  - `GET /next?current_id=ID` returns the next unlabeled image; headers describe prediction or existing annotation.
+  - `GET /next?current_id=ID&strategy=STRAT` returns the next unlabeled image.
+    `STRAT` may be `sequential` or `least_confident_minority` (default). Headers
+    describe prediction or existing annotation.
   - `GET /sample?id=ID` serves an image by ID with the same headers.
   - `POST /annotate` stores `{filepath, class}` (and optional bbox/point info).
   - `DELETE /annotate` removes the label annotation for a filepath.

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -71,7 +71,7 @@ async def get_sample_by_id(request):
 
 async def get_next_sample(request):
     current_id = request.query_params.get("current_id")
-    strategy = request.query_params.get("strategy")
+    strategy = request.query_params.get("strategy", "least_confident_minority")
 
     # Sequential strategy (existing behaviour)
     def sequential_next():
@@ -82,12 +82,12 @@ async def get_next_sample(request):
 
     if strategy == "sequential":
         return sequential_next()
-
-    # Default active learning strategy using DatabaseAPI
-    filepath = db.get_next_unlabeled_default(current_id)
-    if filepath:
-        return create_image_response(filepath)
-    return sequential_next()
+    if strategy == "least_confident_minority":
+        filepath = db.get_next_unlabeled_default(current_id)
+        if filepath:
+            return create_image_response(filepath)
+        return sequential_next()
+    return JSONResponse({"error": "Invalid strategy"}, status_code=400)
 
 
 async def handle_annotation(request: Request):

--- a/src/frontend2/index.html
+++ b/src/frontend2/index.html
@@ -16,6 +16,13 @@
                 <!-- Right Panel: Controls -->
                 <div class="right-panel">
                         <button id="undo-btn" class="undo-btn">Undo</button>
+                        <div class="strategy-control">
+                                <label for="strategy-select">Next image strategy:</label>
+                                <select id="strategy-select">
+                                        <option value="least_confident_minority">Least Confident Minority</option>
+                                        <option value="sequential">Sequential</option>
+                                </select>
+                        </div>
                         <div id="stats-display" class="info-display"></div>
                         <div id="class-manager"></div>
                 </div>

--- a/src/frontend2/js/api.js
+++ b/src/frontend2/js/api.js
@@ -2,11 +2,17 @@
 
 export class API {
     // Load the next image sample (image response, not JSON)
-    async loadNextImage(currentId = null) {
+    async loadNextImage(currentId = null, strategy = null) {
         let url = '/next';
+        const params = new URLSearchParams();
         if (currentId) {
-            url += `?current_id=${encodeURIComponent(currentId)}`;
+            params.append('current_id', currentId);
         }
+        if (strategy) {
+            params.append('strategy', strategy);
+        }
+        const qs = params.toString();
+        if (qs) url += `?${qs}`;
         const res = await fetch(url);
         if (!res.ok) throw new Error('No images available');
         const filename = res.headers.get('X-Image-Id') || res.headers.get('X-Filename');

--- a/src/frontend2/js/app.js
+++ b/src/frontend2/js/app.js
@@ -9,6 +9,13 @@ document.addEventListener('DOMContentLoaded', async () => {
         const classPanel = document.querySelector('#class-manager');
         const undoBtn = document.getElementById('undo-btn');
         const statsDiv = document.getElementById('stats-display');
+        const strategySelect = document.getElementById('strategy-select');
+        let currentStrategy = strategySelect ? strategySelect.value : null;
+        if (strategySelect) {
+                strategySelect.addEventListener('change', () => {
+                        currentStrategy = strategySelect.value;
+                });
+        }
         if (!leftPanel) {
                 console.error('Left panel container not found.');
                 return;
@@ -63,7 +70,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         async function loadNextImage() {
                 try {
                         const currentId = classManager.currentImageFilename;
-                        const { imageUrl, filename, labelClass, labelSource } = await api.loadNextImage(currentId);
+                        const { imageUrl, filename, labelClass, labelSource } = await api.loadNextImage(currentId, currentStrategy);
                         viewer.loadImage(imageUrl, filename);
                         const annClass = labelSource === 'annotation' ? labelClass : null;
                         await classManager.setCurrentImageFilename(filename, annClass);
@@ -85,7 +92,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
 	// Fetch the first image from API
         try {
-                const { imageUrl, filename, labelClass, labelSource } = await api.loadNextImage();
+                const { imageUrl, filename, labelClass, labelSource } = await api.loadNextImage(null, currentStrategy);
                 viewer.loadImage(imageUrl, filename);
                 const annClass = labelSource === 'annotation' ? labelClass : null;
                 await classManager.setCurrentImageFilename(filename, annClass);

--- a/src/frontend2/style.css
+++ b/src/frontend2/style.css
@@ -201,3 +201,15 @@ body {
 .status-implemented { color: #28a745; }
 .status-partial { color: #ffc107; }
 .status-missing { color: #dc3545; }
+
+.strategy-control {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+}
+
+.strategy-control select {
+        padding: 6px;
+        border: 1px solid #ced4da;
+        border-radius: 4px;
+}


### PR DESCRIPTION
## Summary
- allow choosing the next sampling strategy from the UI
- send strategy via `/next` endpoint
- support `sequential` and `least_confident_minority` strategies on the backend
- document strategy parameter in the spec

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688cb74ceb9c832fab4d57e7823769b2