### PR TITLE
Enable model checkpointing

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -26,8 +26,9 @@ A human-in-the-loop image annotation system with continuous training.
 - `src/ml/fastai_training.py` loops forever:
   1. Gather latest label annotations and build `DataLoaders`.
   2. Train one epoch on ResNet (34 or `--arch small` for 18).
-  3. Predict on remaining unlabeled images and write predictions to DB.
-  4. Sleep for a configurable delay and repeat.
+  3. Save the model weights to `<db>.pth` so progress persists across runs.
+  4. Predict on remaining unlabeled images and write predictions to DB.
+  5. Sleep for a configurable delay and repeat.
 
 ## Usage
 1. Start backend: `uvicorn src.backend.main:app`.

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # The ultimate image annotation tool
 
-Fast image labeling with human-in-the-loop training. The Starlette backend serves a simple JS frontend and a FastAI loop keeps learning from your annotations.
+Fast image labeling with human-in-the-loop training. The Starlette backend serves a simple JS frontend and a FastAI loop keeps learning from your annotations. Model checkpoints are saved next to the dataset so progress persists across training runs.
 
 Run the server with:
 


### PR DESCRIPTION
## Summary
- checkpoint the model to `<db>.pth` and load it on startup
- document checkpointing in `SPEC.md`
- mention persistence in the README

## Testing
- `python -m py_compile src/ml/fastai_training.py`
- `python -m py_compile src/backend/main.py src/database/data.py`
- `python -m src.ml.fastai_training --help` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch --extra-index-url https://download.pytorch.org/whl/cpu` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_688cb69e7434832f852d4d90c3d19985