### PR TITLE
Expose training curve

### DIFF
--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -169,6 +169,10 @@ async def get_stats(request: Request):
         }
     )
 
+async def get_training_stats(request: Request):
+    stats = db.get_training_stats()
+    return JSONResponse(stats)
+
 app = Starlette(
     routes=[
         Route("/config", put_config, methods=["PUT"]),
@@ -178,6 +182,7 @@ app = Starlette(
         Route("/annotate", handle_annotation, methods=["POST"]),
         Route("/annotate", handle_annotation, methods=["DELETE"]),
         Route("/stats", get_stats, methods=["GET"]),
+        Route("/training_stats", get_training_stats, methods=["GET"]),
     ]
 )
 app.mount("/", StaticFiles(directory=FRONTEND_DIR, html=True), name="frontend")

--- a/src/frontend2/index.html
+++ b/src/frontend2/index.html
@@ -17,6 +17,7 @@
                 <div class="right-panel">
                         <button id="undo-btn" class="undo-btn">Undo</button>
                         <div id="stats-display" class="info-display"></div>
+                        <canvas id="training-curve" width="300" height="150" style="border:1px solid #ccc;"></canvas>
                         <div id="class-manager"></div>
                 </div>
                 <script type="module" src="js/app.js"></script>

--- a/src/frontend2/js/api.js
+++ b/src/frontend2/js/api.js
@@ -75,4 +75,10 @@ export class API {
         if (!res.ok) throw new Error('Failed to get stats');
         return await res.json();
     }
+
+    async getTrainingStats() {
+        const res = await fetch('/training_stats');
+        if (!res.ok) throw new Error('Failed to get training stats');
+        return await res.json();
+    }
 }

--- a/src/frontend2/js/app.js
+++ b/src/frontend2/js/app.js
@@ -4,11 +4,12 @@ import { API } from './api.js';
 import { UndoManager } from './undoManager.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
-	// Get left and right panel containers
+        // Get left and right panel containers
         const leftPanel = document.querySelector('.left-panel');
         const classPanel = document.querySelector('#class-manager');
         const undoBtn = document.getElementById('undo-btn');
         const statsDiv = document.getElementById('stats-display');
+        const trainingCanvas = document.getElementById('training-curve');
         if (!leftPanel) {
                 console.error('Left panel container not found.');
                 return;
@@ -56,6 +57,41 @@ document.addEventListener('DOMContentLoaded', async () => {
                 }
         }
 
+        async function updateTrainingCurve() {
+                if (!trainingCanvas) return;
+                try {
+                        const data = await api.getTrainingStats();
+                        drawCurve(trainingCanvas, data.map(d => ({x: d.epoch, y: d.accuracy ?? 0})));
+                } catch (e) {
+                        console.error('Failed to fetch training stats:', e);
+                }
+        }
+
+        function drawCurve(canvas, points) {
+                const ctx = canvas.getContext('2d');
+                const w = canvas.width;
+                const h = canvas.height;
+                ctx.clearRect(0, 0, w, h);
+                if (!points || points.length === 0) return;
+                const padding = 20;
+                const maxX = points[points.length - 1].x || 1;
+                ctx.strokeStyle = '#ccc';
+                ctx.beginPath();
+                ctx.moveTo(padding, padding);
+                ctx.lineTo(padding, h - padding);
+                ctx.lineTo(w - padding, h - padding);
+                ctx.stroke();
+
+                ctx.strokeStyle = '#007acc';
+                ctx.beginPath();
+                points.forEach((p, idx) => {
+                        const x = padding + (p.x / maxX) * (w - 2 * padding);
+                        const y = h - padding - (p.y) * (h - 2 * padding);
+                        if (idx === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+                });
+                ctx.stroke();
+        }
+
 	// Create the viewer instance
 	const viewer = new ImageViewer(leftPanel, 'loading-overlay', 'c');
 
@@ -68,6 +104,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                         const annClass = labelSource === 'annotation' ? labelClass : null;
                         await classManager.setCurrentImageFilename(filename, annClass);
                         await updateStats();
+                        await updateTrainingCurve();
                 } catch (e) {
                         console.error('Failed to fetch next image:', e);
                 }
@@ -90,8 +127,12 @@ document.addEventListener('DOMContentLoaded', async () => {
                 const annClass = labelSource === 'annotation' ? labelClass : null;
                 await classManager.setCurrentImageFilename(filename, annClass);
                 await updateStats();
+                await updateTrainingCurve();
         } catch (e) {
                 console.error('Failed to fetch first image:', e);
                 return;
         }
+
+        updateTrainingCurve();
+        setInterval(updateTrainingCurve, 5000);
 });

--- a/src/frontend2/style.css
+++ b/src/frontend2/style.css
@@ -140,7 +140,14 @@ body {
 }
 
 .info-display b {
-	color: #495057;
+        color: #495057;
+}
+
+#training-curve {
+        width: 100%;
+        max-width: 300px;
+        height: 150px;
+        border: 1px solid #ccc;
 }
 
 .prediction-badge {

--- a/src/ml/fastai_training.py
+++ b/src/ml/fastai_training.py
@@ -141,6 +141,16 @@ def _run_forever(db_path: str | None, arch: str, sleep_s: int) -> None:
             learner.fit(1)
             epoch_time = time.time() - t0
 
+            try:
+                valid_res = learner.validate()
+                valid_loss = float(valid_res[0]) if len(valid_res) > 0 else None
+                accuracy_val = float(valid_res[1]) if len(valid_res) > 1 else None
+                train_loss = float(learner.recorder.losses[-1]) if learner.recorder.losses else None
+            except Exception:
+                train_loss = valid_loss = accuracy_val = None
+
+            db.add_training_stat(cycle, train_loss, valid_loss, accuracy_val)
+
             budget = max(10, int(2 * epoch_time))
             labeled_set = set(paths)
             unlabeled = [fp for fp in db.get_samples() if fp not in labeled_set]


### PR DESCRIPTION
## Summary
- track training stats in the database
- expose `/training_stats` endpoint
- draw training curve in the new frontend without external libraries

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688cb7129244832f9ed5b705509206da