### PR TITLE
Adjust component order in frontend2

### DIFF
--- a/src/frontend2/index.html
+++ b/src/frontend2/index.html
@@ -15,17 +15,17 @@
 		
                 <!-- Right Panel: Controls -->
                 <div class="right-panel">
-                        <button id="undo-btn" class="undo-btn">Undo</button>
-                        <div class="strategy-control">
+                    <div id="class-manager"></div>
+                    <div class="strategy-control">
                                 <label for="strategy-select">Next image strategy:</label>
                                 <select id="strategy-select">
                                         <option value="least_confident_minority">Least Confident Minority</option>
                                         <option value="sequential">Sequential</option>
                                 </select>
                         </div>
+                        <button id="undo-btn" class="undo-btn">Undo</button>
                         <div id="stats-display" class="info-display"></div>
                         <canvas id="training-curve" width="300" height="150" style="border:1px solid #ccc;"></canvas>
-                        <div id="class-manager"></div>
                 </div>
                 <script type="module" src="js/app.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- reorder controls in `src/frontend2/index.html` so class manager comes first
- move undo button after strategy selector and before stats display

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d31bc790c832f828d12962fd1fe35