### PR TITLE
Add last-class active learning strategy

### DIFF
--- a/src/frontend2/index.html
+++ b/src/frontend2/index.html
@@ -21,6 +21,7 @@
                                 <select id="strategy-select">
                                         <option value="least_confident_minority">Least Confident Minority</option>
                                         <option value="sequential">Sequential</option>
+                                        <option value="last_class">Highest Probability Last Class</option>
                                 </select>
                         </div>
                         <button id="undo-btn" class="undo-btn">Undo</button>


### PR DESCRIPTION
## Summary
- Track recent annotations in a backend buffer to guide sampling
- Implement `last_class` active learning strategy that serves images predicted to match the most recent class
- Expose the strategy via frontend dropdown

## Testing
- `python -m py_compile src/backend/main.py src/database/data.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688df619c354832fb4dd44eb31e5714e