### PR TITLE
Add specific class active learning strategy

### DIFF
--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -102,6 +102,16 @@ async def get_next_sample(request):
         if filepath:
             return create_image_response(filepath)
         return sequential_next()
+    if strategy == "specific_class":
+        target_class = request.query_params.get("class")
+        if target_class:
+            filepath = db.get_next_unlabeled_for_class(target_class, current_id)
+            if filepath:
+                return create_image_response(filepath)
+        filepath = db.get_next_unlabeled_default(current_id)
+        if filepath:
+            return create_image_response(filepath)
+        return sequential_next()
     return JSONResponse({"error": "Invalid strategy"}, status_code=400)
 
 

--- a/src/frontend2/index.html
+++ b/src/frontend2/index.html
@@ -22,7 +22,10 @@
                                         <option value="least_confident_minority">Least Confident Minority</option>
                                         <option value="sequential">Sequential</option>
                                         <option value="last_class">Highest Probability Last Class</option>
+                                        <option value="specific_class">Specific Class</option>
                                 </select>
+                                <label id="specific-class-label" for="specific-class-select" style="display:none;">Class:</label>
+                                <select id="specific-class-select" style="display:none;"></select>
                         </div>
                         <button id="undo-btn" class="undo-btn">Undo</button>
                         <div id="stats-display" class="info-display"></div>

--- a/src/frontend2/js/api.js
+++ b/src/frontend2/js/api.js
@@ -2,7 +2,7 @@
 
 export class API {
     // Load the next image sample (image response, not JSON)
-    async loadNextImage(currentId = null, strategy = null) {
+    async loadNextImage(currentId = null, strategy = null, className = null) {
         let url = '/next';
         const params = new URLSearchParams();
         if (currentId) {
@@ -10,6 +10,9 @@ export class API {
         }
         if (strategy) {
             params.append('strategy', strategy);
+        }
+        if (className) {
+            params.append('class', className);
         }
         const qs = params.toString();
         if (qs) url += `?${qs}`;

--- a/src/frontend2/js/app.js
+++ b/src/frontend2/js/app.js
@@ -11,10 +11,25 @@ document.addEventListener('DOMContentLoaded', async () => {
         const statsDiv = document.getElementById('stats-display');
         const trainingCanvas = document.getElementById('training-curve');
         const strategySelect = document.getElementById('strategy-select');
+        const specificClassSelect = document.getElementById('specific-class-select');
+        const specificClassLabel = document.getElementById('specific-class-label');
         let currentStrategy = strategySelect ? strategySelect.value : null;
+        let currentSpecificClass = specificClassSelect ? specificClassSelect.value : null;
+        function toggleSpecificClassSelect() {
+                const show = currentStrategy === 'specific_class';
+                if (specificClassSelect) specificClassSelect.style.display = show ? 'inline-block' : 'none';
+                if (specificClassLabel) specificClassLabel.style.display = show ? 'inline-block' : 'none';
+        }
+        toggleSpecificClassSelect();
         if (strategySelect) {
                 strategySelect.addEventListener('change', () => {
                         currentStrategy = strategySelect.value;
+                        toggleSpecificClassSelect();
+                });
+        }
+        if (specificClassSelect) {
+                specificClassSelect.addEventListener('change', () => {
+                        currentSpecificClass = specificClassSelect.value;
                 });
         }
         if (!leftPanel) {
@@ -102,11 +117,11 @@ document.addEventListener('DOMContentLoaded', async () => {
 	// Create the viewer instance
 	const viewer = new ImageViewer(leftPanel, 'loading-overlay', 'c');
 
-	// Helper to load next image from API and update viewer/classManager
+        // Helper to load next image from API and update viewer/classManager
         async function loadNextImage() {
                 try {
                         const currentId = classManager.currentImageFilename;
-                        const { imageUrl, filename, labelClass, labelSource } = await api.loadNextImage(currentId, currentStrategy);
+                        const { imageUrl, filename, labelClass, labelSource } = await api.loadNextImage(currentId, currentStrategy, currentSpecificClass);
                         viewer.loadImage(imageUrl, filename);
                         const annClass = labelSource === 'annotation' ? labelClass : null;
                         await classManager.setCurrentImageFilename(filename, annClass);
@@ -126,10 +141,16 @@ document.addEventListener('DOMContentLoaded', async () => {
         classManager.setOnClassChange((filename, cls) => {
                 undoManager.record(filename);
         });
+        classManager.setOnClassesUpdate((classes) => {
+                if (specificClassSelect) {
+                        specificClassSelect.innerHTML = classes.map(c => `<option value="${c}">${c}</option>`).join('');
+                        currentSpecificClass = specificClassSelect.value || null;
+                }
+        });
 
 	// Fetch the first image from API
         try {
-                const { imageUrl, filename, labelClass, labelSource } = await api.loadNextImage(null, currentStrategy);
+                const { imageUrl, filename, labelClass, labelSource } = await api.loadNextImage(null, currentStrategy, currentSpecificClass);
                 viewer.loadImage(imageUrl, filename);
                 const annClass = labelSource === 'annotation' ? labelClass : null;
                 await classManager.setCurrentImageFilename(filename, annClass);

--- a/src/frontend2/js/classManager.js
+++ b/src/frontend2/js/classManager.js
@@ -21,6 +21,7 @@ export class ClassManager {
     this.selectedClass = null;
     this.currentImageFilename = null;
     this.onClassChange = null; // callback(filename, className)
+    this.onClassesUpdate = null; // callback(classes[])
     this.loadNextImage = loadNextImage;
     this.api = api;
 
@@ -94,6 +95,10 @@ export class ClassManager {
     }
     setOnClassChange(callback) {
         this.onClassChange = callback;
+    }
+
+    setOnClassesUpdate(callback) {
+        this.onClassesUpdate = callback;
     }
 
     // Add a new class if not already present
@@ -212,5 +217,8 @@ export class ClassManager {
             });
         }
         this.container.appendChild(classListDiv);
+        if (this.onClassesUpdate) {
+            this.onClassesUpdate([...this.globalClasses]);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add "Specific Class" active learning option to frontend with class selector dropdown
- Support requesting next sample for a selected class via API and backend strategy
- Notify UI of class list changes so selector stays in sync

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e0300aca8832f813c46b444525df5