### PR TITLE
Fix class selection resetting after annotation

### DIFF
--- a/src/frontend2/js/classManager.js
+++ b/src/frontend2/js/classManager.js
@@ -81,7 +81,9 @@ export class ClassManager {
     // Setters for state
     async setCurrentImageFilename(filename, selectedClass = null) {
         this.currentImageFilename = filename;
-        this.selectedClass = selectedClass;
+        if (selectedClass !== null) {
+            this.selectedClass = selectedClass;
+        }
         await this.loadClassesFromConfig();
         this.render();
     }


### PR DESCRIPTION
## Summary
- Preserve selected class when loading new images

## Testing
- `node --check src/frontend2/js/classManager.js`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688e082d308c832f932b66ef9860c012