### PR TITLE
Add accuracy window slider and clarify test accuracy

### DIFF
--- a/src/frontend2/index.html
+++ b/src/frontend2/index.html
@@ -16,7 +16,7 @@
                 <!-- Right Panel: Controls -->
                 <div class="right-panel">
                     <div id="class-manager"></div>
-                    <div class="strategy-control">
+                        <div class="strategy-control">
                                 <label for="strategy-select">Next image strategy:</label>
                                 <select id="strategy-select">
                                         <option value="least_confident_minority">Least Confident Minority</option>
@@ -25,6 +25,11 @@
                                 </select>
                         </div>
                         <button id="undo-btn" class="undo-btn">Undo</button>
+                        <div class="accuracy-filter">
+                                <label for="accuracy-slider">Accuracy window:</label>
+                                <input type="range" id="accuracy-slider" min="0" max="100" value="100">
+                                <span id="accuracy-slider-value">100%</span>
+                        </div>
                         <div id="stats-display" class="info-display"></div>
                         <canvas id="training-curve" width="300" height="150" style="border:1px solid #ccc;"></canvas>
                 </div>

--- a/src/frontend2/js/api.js
+++ b/src/frontend2/js/api.js
@@ -75,9 +75,14 @@ export class API {
         return await res.json();
     }
 
-    // Get accuracy stats
-    async getStats() {
-        const res = await fetch('/stats');
+    // Get accuracy stats with optional window percentage
+    async getStats(pct = 100) {
+        let url = '/stats';
+        if (typeof pct === 'number') {
+            const params = new URLSearchParams({ pct: pct.toString() });
+            url += `?${params.toString()}`;
+        }
+        const res = await fetch(url);
         if (!res.ok) throw new Error('Failed to get stats');
         return await res.json();
     }

--- a/src/frontend2/js/app.js
+++ b/src/frontend2/js/app.js
@@ -11,6 +11,17 @@ document.addEventListener('DOMContentLoaded', async () => {
         const statsDiv = document.getElementById('stats-display');
         const trainingCanvas = document.getElementById('training-curve');
         const strategySelect = document.getElementById('strategy-select');
+        const accuracySlider = document.getElementById('accuracy-slider');
+        const accuracyValue = document.getElementById('accuracy-slider-value');
+        let accuracyPct = accuracySlider ? Number(accuracySlider.value) : 100;
+        if (accuracyValue) accuracyValue.textContent = `${accuracyPct}%`;
+        if (accuracySlider) {
+                accuracySlider.addEventListener('input', () => {
+                        accuracyPct = Number(accuracySlider.value);
+                        if (accuracyValue) accuracyValue.textContent = `${accuracyPct}%`;
+                        updateStats();
+                });
+        }
         let currentStrategy = strategySelect ? strategySelect.value : null;
         if (strategySelect) {
                 strategySelect.addEventListener('change', () => {
@@ -32,7 +43,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         async function updateStats() {
                 if (!statsDiv) return;
                 try {
-                        const stats = await api.getStats();
+                        const stats = await api.getStats(accuracyPct);
                         if (stats) {
                                 let html = '';
                                 if (stats.image) {
@@ -52,9 +63,9 @@ document.addEventListener('DOMContentLoaded', async () => {
 
                                 if (typeof stats.accuracy === 'number') {
                                         const pct = (stats.accuracy * 100).toFixed(1);
-                                        html += `<div><b>Accuracy:</b> <span class="accuracy-badge">${pct}%</span></div>`;
+                                        html += `<div><b>Test Accuracy:</b> <span class="accuracy-badge">${pct}%</span></div>`;
                                 } else {
-                                        html += `<div><b>Accuracy:</b> <span class="accuracy-badge">0%</span></div>`;
+                                        html += `<div><b>Test Accuracy:</b> <span class="accuracy-badge">0%</span></div>`;
                                 }
 
                                 statsDiv.innerHTML = html;
@@ -99,7 +110,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 ctx.save();
                 ctx.translate(10, h / 2);
                 ctx.rotate(-Math.PI / 2);
-                ctx.fillText('Accuracy', 0, 0);
+                ctx.fillText('Test Accuracy', 0, 0);
                 ctx.restore();
 
                 // tick marks

--- a/src/frontend2/style.css
+++ b/src/frontend2/style.css
@@ -220,3 +220,10 @@ body {
         border: 1px solid #ced4da;
         border-radius: 4px;
 }
+
+.accuracy-filter {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 14px;
+}


### PR DESCRIPTION
## Summary
- Track individual prediction results and expose accuracy over a recent percentage of samples
- Add UI slider to choose accuracy window and label stats as Test Accuracy
- Rename training curve axis to "Test Accuracy"

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e070f7784832fb2f8bd704348cd1d