### PR TITLE
Preserve class selection when class list updates

### DIFF
--- a/src/frontend2/js/app.js
+++ b/src/frontend2/js/app.js
@@ -180,7 +180,13 @@ document.addEventListener('DOMContentLoaded', async () => {
         });
         classManager.setOnClassesUpdate((classes) => {
                 if (specificClassSelect) {
+                        const previous = specificClassSelect.value;
                         specificClassSelect.innerHTML = classes.map(c => `<option value="${c}">${c}</option>`).join('');
+                        if (classes.includes(previous)) {
+                                specificClassSelect.value = previous;
+                        } else if (classes.length > 0) {
+                                specificClassSelect.selectedIndex = 0;
+                        }
                         currentSpecificClass = specificClassSelect.value || null;
                 }
         });


### PR DESCRIPTION
## Summary
- Preserve previously selected class when class list updates in frontend by storing prior value before repopulating options and restoring if still present.
- Update `currentSpecificClass` to match the restored selection or first option.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688e126f6a0c832faeb0aee860414960