### PR TITLE
Add database export endpoint and frontend download

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,7 @@ python -m src.ml.fastai_training --arch vit_medium_patch16_reg4_gap_256.sbb_in12
   - `DELETE /annotate` removes the label annotation for a filepath.
   - `GET /stats` reports image counts, annotations per class and model
     performance metrics such as accuracy and error rates.
+  - `GET /export_db` downloads the current database as JSON.
 - **DatabaseAPI** (`src/database/data.py`)
   - SQLite tables: `samples(filepath)`, `annotations(id, sample_id, sample_filepath, type, class, x, y, width, height, timestamp)`, `predictions(id, sample_id, sample_filepath, type, class, probability, x, y, width, height)`, `config(architecture, classes)`, `accuracy_stats(tries, correct)`.
   - Methods to set/get samples, annotations, predictions and export DB to JSON.
@@ -50,7 +51,7 @@ python -m src.ml.fastai_training --arch vit_medium_patch16_reg4_gap_256.sbb_in12
 2. Open the frontend in a browser.
 3. Annotate using the UI (`/next` fetches an image; `/annotate` saves it).
 4. Run `python -m src.ml.fastai_training` to train and update predictions.
-5. Export the DB with `DatabaseAPI.export_db_as_json(path)` when done.
+5. Export the DB via the "Export DB" button or `GET /export_db` when done.
 
 # TO-DO
 

--- a/src/frontend2/index.html
+++ b/src/frontend2/index.html
@@ -28,6 +28,7 @@
                                 <select id="specific-class-select" style="display:none;"></select>
                         </div>
                         <button id="undo-btn" class="undo-btn">Undo</button>
+                        <button id="export-db-btn" class="export-btn">Export DB</button>
                         <div class="accuracy-filter">
                                 <label for="accuracy-slider">Accuracy window:</label>
                                 <input type="range" id="accuracy-slider" min="0" max="100" value="100">

--- a/src/frontend2/js/api.js
+++ b/src/frontend2/js/api.js
@@ -95,4 +95,18 @@ export class API {
         if (!res.ok) throw new Error('Failed to get training stats');
         return await res.json();
     }
+
+    async exportDB() {
+        const res = await fetch('/export_db');
+        if (!res.ok) throw new Error('Failed to export DB');
+        const blob = await res.blob();
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'db_export.json';
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        URL.revokeObjectURL(url);
+    }
 }

--- a/src/frontend2/js/app.js
+++ b/src/frontend2/js/app.js
@@ -8,6 +8,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         const leftPanel = document.querySelector('.left-panel');
         const classPanel = document.querySelector('#class-manager');
         const undoBtn = document.getElementById('undo-btn');
+        const exportDBBtn = document.getElementById('export-db-btn');
         const statsDiv = document.getElementById('stats-display');
         const trainingCanvas = document.getElementById('training-curve');
         const strategySelect = document.getElementById('strategy-select');
@@ -54,6 +55,9 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         // Create the API instance
         const api = new API();
+        if (exportDBBtn) {
+                exportDBBtn.addEventListener('click', () => api.exportDB());
+        }
 
         async function updateStats() {
                 if (!statsDiv) return;


### PR DESCRIPTION
## Summary
- expose `GET /export_db` to dump current database as JSON
- add frontend button and API helper to download the export
- document export workflow in README
- wire up export button through `app.js` instead of inline script

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e209841a0832f8371d3b728632fe4