### PR TITLE
Fetch stats only on image change

### DIFF
--- a/src/frontend2/js/app.js
+++ b/src/frontend2/js/app.js
@@ -219,6 +219,4 @@ document.addEventListener('DOMContentLoaded', async () => {
                 return;
         }
 
-        updateTrainingCurve();
-        setInterval(updateTrainingCurve, 5000);
 });


### PR DESCRIPTION
## Summary
- Stop fetching training stats on a timer in the new frontend so stats update only after loading a new image

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e31b3c69c832fa0870dea7e187c6e