### PR TITLE
Improve UI styling and shortcuts

### DIFF
--- a/src/frontend2/index.html
+++ b/src/frontend2/index.html
@@ -2,8 +2,11 @@
 <html lang="en">
 
 <head>
-	<meta charset="utf-8" />
-	<link rel="stylesheet" href="style.css" />
+        <meta charset="utf-8" />
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="style.css" />
 </head>
 
 <body>
@@ -27,8 +30,8 @@
                                 <label id="specific-class-label" for="specific-class-select" style="display:none;">Class:</label>
                                 <select id="specific-class-select" style="display:none;"></select>
                         </div>
-                        <button id="undo-btn" class="undo-btn">Undo</button>
-                        <button id="export-db-btn" class="export-btn">Export DB</button>
+                        <button id="undo-btn" class="undo-btn">Undo (Ctrl+Z/U/Backspace)</button>
+                        <button id="export-db-btn" class="export-btn">Export DB (Ctrl+E)</button>
                         <div class="accuracy-filter">
                                 <label for="accuracy-slider">Accuracy window:</label>
                                 <input type="range" id="accuracy-slider" min="0" max="100" value="100">

--- a/src/frontend2/js/app.js
+++ b/src/frontend2/js/app.js
@@ -60,6 +60,14 @@ document.addEventListener('DOMContentLoaded', async () => {
                 exportDBBtn.addEventListener('click', () => api.exportDB());
         }
 
+        document.addEventListener('keydown', (e) => {
+                if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+                if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'e') {
+                        e.preventDefault();
+                        api.exportDB();
+                }
+        });
+
         function updatePrediction(labelClass, labelProbability, labelSource) {
                 if (!predictionDiv) return;
                 if (labelSource === 'prediction' && labelClass) {
@@ -101,9 +109,9 @@ document.addEventListener('DOMContentLoaded', async () => {
 
                                 if (typeof stats.accuracy === 'number') {
                                         const pct = (stats.accuracy * 100).toFixed(1);
-                                        html += `<div><b>Test Accuracy:</b> <span class="accuracy-badge">${pct}%</span></div>`;
+                                        html += `<div><b>Val Accuracy:</b> <span class="accuracy-badge">${pct}%</span></div>`;
                                 } else {
-                                        html += `<div><b>Test Accuracy:</b> <span class="accuracy-badge">0%</span></div>`;
+                                        html += `<div><b>Val Accuracy:</b> <span class="accuracy-badge">0%</span></div>`;
                                 }
 
                                 statsDiv.innerHTML = html;
@@ -141,14 +149,14 @@ document.addEventListener('DOMContentLoaded', async () => {
                 ctx.lineTo(w - padding, h - padding);
                 ctx.stroke();
 
-                ctx.fillStyle = '#000';
-                ctx.font = '12px sans-serif';
+                ctx.fillStyle = '#e0e0e0';
+                ctx.font = '12px Roboto, sans-serif';
                 ctx.textAlign = 'center';
                 ctx.fillText('Epoch', w / 2, h - 5);
                 ctx.save();
-                ctx.translate(10, h / 2);
+                ctx.translate(padding - 25, h / 2);
                 ctx.rotate(-Math.PI / 2);
-                ctx.fillText('Test Accuracy', 0, 0);
+                ctx.fillText('Val Accuracy', 0, 0);
                 ctx.restore();
 
                 // tick marks

--- a/src/frontend2/js/undoManager.js
+++ b/src/frontend2/js/undoManager.js
@@ -6,10 +6,14 @@ export class UndoManager {
         this.updatePrediction = updatePrediction;
         this.history = [];
 
-        // Keyboard shortcuts for undo: Backspace or 'u'
+        // Keyboard shortcuts for undo
         document.addEventListener('keydown', (e) => {
             if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
-            if (e.key === 'Backspace' || e.key.toLowerCase() === 'u') {
+            const key = e.key.toLowerCase();
+            if ((e.ctrlKey || e.metaKey) && key === 'z') {
+                e.preventDefault();
+                this.undo();
+            } else if (e.key === 'Backspace' || key === 'u') {
                 e.preventDefault();
                 this.undo();
             }

--- a/src/frontend2/style.css
+++ b/src/frontend2/style.css
@@ -2,9 +2,10 @@ body {
         margin: 0;
         display: flex;
         height: 100vh;
-        font-family: Arial, sans-serif;
+        font-family: 'Roboto', sans-serif;
+        font-weight: 300;
         background: #121212;
-        color: #f8f9fa;
+        color: #f0f0f0;
 }
 
 .main-container {
@@ -147,12 +148,34 @@ body {
 
 .undo-btn {
         padding: 8px 12px;
-        border: 1px solid #ffc107;
-        background: #ffc107;
-        color: black;
+        border: none;
+        background: linear-gradient(45deg, #fbc02d, #ffeb3b);
+        color: #212121;
         border-radius: 4px;
         cursor: pointer;
         margin-bottom: 10px;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+        transition: background 0.3s;
+}
+
+.undo-btn:hover {
+        background: linear-gradient(45deg, #f9a825, #fbc02d);
+}
+
+.export-btn {
+        padding: 8px 12px;
+        border: none;
+        background: linear-gradient(45deg, #8e24aa, #ba68c8);
+        color: #f8f9fa;
+        border-radius: 4px;
+        cursor: pointer;
+        margin-bottom: 10px;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+        transition: background 0.3s;
+}
+
+.export-btn:hover {
+        background: linear-gradient(45deg, #7b1fa2, #8e24aa);
 }
 
 .info-display {
@@ -176,17 +199,19 @@ body {
 }
 
 .prediction-badge {
-	background: #ffe0b2;
-	padding: 3px 8px;
-	border-radius: 4px;
-	display: inline-block;
+        background: #ff7043;
+        color: #ffffff;
+        padding: 3px 8px;
+        border-radius: 4px;
+        display: inline-block;
 }
 
 .accuracy-badge {
-	background: #c8e6c9;
-	padding: 3px 8px;
-	border-radius: 4px;
-	display: inline-block;
+        background: #43a047;
+        color: #ffffff;
+        padding: 3px 8px;
+        border-radius: 4px;
+        display: inline-block;
 }
 
 #dev-checklist {


### PR DESCRIPTION
## Summary
- switch to Roboto font and lighten text for dark theme
- restyle undo/export buttons and display keyboard shortcuts
- show validation accuracy and adjust training curve label positioning

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e57f6fc10832f819e1c460c23e987