### PR TITLE
Simplify stats storage with unified table

### DIFF
--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -134,7 +134,6 @@ async def handle_annotation(request: Request):
         pred_ann = next((p for p in preds if p.get('type') == 'label' and p.get('probability') is not None), None)
         if pred_ann:
             was_correct = str(pred_ann.get("class")) == str(class_name)
-            db.increment_accuracy(was_correct)
             db.log_accuracy(was_correct)
         return JSONResponse({"status": "ok"})
     elif request.method == "DELETE":


### PR DESCRIPTION
## Summary
- consolidate accuracy and training metrics into a single `stats` table
- adjust DB API to read/write accuracy logs and training stats from unified table
- simplify backend annotation handler to log accuracy once

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e217ed094832f9cf3941acc2f40bc