### PR TITLE
Return empty config instead of 404

### DIFF
--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -177,9 +177,9 @@ async def put_config(request: Request):
 
 async def get_config(request: Request):
     cfg = db.get_config()
-    if not cfg:
-        return JSONResponse({"error": "No config set"}, status_code=404)
-
+    # Treat an empty configuration as a valid result instead of returning 404.
+    # The database returns an empty dict when no config has been saved yet, so
+    # simply return that to the client.
     print("Config updated", cfg)
     return JSONResponse(cfg)
 


### PR DESCRIPTION
## Summary
- Ensure `/config` endpoint returns an empty object instead of 404 when no config is stored

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e62aa25d8832f8e198f3cdba7bfcf