### PR TITLE
Add run/stop AI controls

### DIFF
--- a/src/frontend2/index.html
+++ b/src/frontend2/index.html
@@ -32,6 +32,14 @@
                         </div>
                         <button id="undo-btn" class="undo-btn">Undo (Ctrl+Z/U/Backspace)</button>
                         <button id="export-db-btn" class="export-btn">Export DB (Ctrl+E)</button>
+                        <div class="ai-control">
+                                <input id="ai-arch" placeholder="architecture">
+                                <input id="ai-sleep" type="number" placeholder="sleep">
+                                <input id="ai-budget" type="number" placeholder="budget">
+                                <input id="ai-resize" type="number" placeholder="resize">
+                                <button id="run-ai-btn" class="run-ai-btn">Run AI</button>
+                                <button id="stop-ai-btn" class="stop-ai-btn">Stop AI</button>
+                        </div>
                         <div class="accuracy-filter">
                                 <label for="accuracy-slider">Accuracy window:</label>
                                 <input type="range" id="accuracy-slider" min="0" max="100" value="100">

--- a/src/frontend2/js/api.js
+++ b/src/frontend2/js/api.js
@@ -98,6 +98,22 @@ export class API {
         return await res.json();
     }
 
+    async runAI(params) {
+        const res = await fetch('/run_ai', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(params)
+        });
+        if (!res.ok) throw new Error('Failed to start AI');
+        return await res.json();
+    }
+
+    async stopAI() {
+        const res = await fetch('/stop_ai', { method: 'POST' });
+        if (!res.ok) throw new Error('Failed to stop AI');
+        return await res.json();
+    }
+
     async exportDB() {
         const res = await fetch('/export_db');
         if (!res.ok) throw new Error('Failed to export DB');

--- a/src/frontend2/js/app.js
+++ b/src/frontend2/js/app.js
@@ -9,6 +9,12 @@ document.addEventListener('DOMContentLoaded', async () => {
         const classPanel = document.querySelector('#class-manager');
         const undoBtn = document.getElementById('undo-btn');
         const exportDBBtn = document.getElementById('export-db-btn');
+        const runBtn = document.getElementById('run-ai-btn');
+        const stopBtn = document.getElementById('stop-ai-btn');
+        const archInput = document.getElementById('ai-arch');
+        const sleepInput = document.getElementById('ai-sleep');
+        const budgetInput = document.getElementById('ai-budget');
+        const resizeInput = document.getElementById('ai-resize');
         const statsDiv = document.getElementById('stats-display');
         const predictionDiv = document.getElementById('prediction-display');
         const trainingCanvas = document.getElementById('training-curve');
@@ -58,6 +64,29 @@ document.addEventListener('DOMContentLoaded', async () => {
         const api = new API();
         if (exportDBBtn) {
                 exportDBBtn.addEventListener('click', () => api.exportDB());
+        }
+        if (runBtn) {
+                runBtn.addEventListener('click', async () => {
+                        try {
+                                await api.runAI({
+                                        architecture: archInput?.value || 'resnet18',
+                                        sleep: Number(sleepInput?.value || 0),
+                                        budget: Number(budgetInput?.value || 1000),
+                                        resize: Number(resizeInput?.value || 64)
+                                });
+                        } catch (e) {
+                                console.error('Failed to start AI:', e);
+                        }
+                });
+        }
+        if (stopBtn) {
+                stopBtn.addEventListener('click', async () => {
+                        try {
+                                await api.stopAI();
+                        } catch (e) {
+                                console.error('Failed to stop AI:', e);
+                        }
+                });
         }
 
         document.addEventListener('keydown', (e) => {

--- a/src/frontend2/style.css
+++ b/src/frontend2/style.css
@@ -283,3 +283,41 @@ body {
         gap: 6px;
         font-size: 14px;
 }
+
+.ai-control {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+}
+
+.ai-control input {
+        padding: 6px;
+        border: 1px solid #ced4da;
+        border-radius: 4px;
+}
+
+.run-ai-btn, .stop-ai-btn {
+        padding: 8px 12px;
+        border: none;
+        color: #f8f9fa;
+        border-radius: 4px;
+        cursor: pointer;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+        transition: background 0.3s;
+}
+
+.run-ai-btn {
+        background: linear-gradient(45deg, #2e7d32, #66bb6a);
+}
+
+.run-ai-btn:hover {
+        background: linear-gradient(45deg, #1b5e20, #2e7d32);
+}
+
+.stop-ai-btn {
+        background: linear-gradient(45deg, #c62828, #e57373);
+}
+
+.stop-ai-btn:hover {
+        background: linear-gradient(45deg, #8e0000, #c62828);
+}


### PR DESCRIPTION
## Summary
- add /run_ai and /stop_ai backend endpoints that launch fastai training with architecture, sleep, budget and resize parameters
- allow training script to accept a configurable resize
- expose Run AI/Stop AI controls in frontend with parameter inputs

## Testing
- `python -m py_compile src/ml/fastai_training.py src/backend/main.py`
- `node --check src/frontend2/js/api.js`
- `node --check src/frontend2/js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_6898d4f490fc832fb0965e855979871c