### PR TITLE
Store session data in dedicated subdirectory

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,13 @@ AI training:
 python -m src.ml.fastai_training --arch vit_medium_patch16_reg4_gap_256.sbb_in12k_ft_in1k
 ```
 
+## Data storage
+
+Runtime artifacts such as the SQLite database and model checkpoints are
+written to `src/database/session` by default. To store them elsewhere, set the
+`HITL_SESSION_DIR` environment variable to the desired directory. Removing this
+directory wipes all progress so the app starts from scratch on the next run.
+
 ## Backend
 - **Framework**: Starlette.
 - **Endpoints**

--- a/src/database/data.py
+++ b/src/database/data.py
@@ -458,7 +458,13 @@ class DatabaseAPI:
 
     def __init__(self, db_path=None):
         if db_path is None:
-            db_path = os.path.join(os.path.dirname(__file__), "annotation.db")
+            session_dir = os.environ.get("HITL_SESSION_DIR") or os.path.join(
+                os.path.dirname(__file__), "session"
+            )
+            os.makedirs(session_dir, exist_ok=True)
+            db_path = os.path.join(session_dir, "annotation.db")
+        else:
+            os.makedirs(os.path.dirname(db_path), exist_ok=True)
         self.db_path = db_path
         self.conn = sqlite3.connect(self.db_path)
         # Enable WAL mode for better concurrency


### PR DESCRIPTION
## Summary
- Save the SQLite database and training checkpoints inside a session subdirectory so all run artifacts live together.
- Document new `HITL_SESSION_DIR` environment variable and reset instructions.

## Testing
- `pytest`
- `python -m py_compile src/database/data.py`


------
https://chatgpt.com/codex/tasks/task_e_6899b5ae2ec8832f9adefd2e29e70192