### PR TITLE
Fix requestId reference error in ClassManager keyboard handler

### DIFF
--- a/src/frontend/js/classManager.js
+++ b/src/frontend/js/classManager.js
@@ -49,9 +49,10 @@ export class ClassManager {
                 const className = this.globalClasses[idx];
                 this.selectedClass = className;
                 if (this.currentImageFilename && className) {
+                    let requestId;
                     try {
                         this.setLoading(true);
-                        let requestId = ++this.annotationRequestId; // declare in outer scope for finally access
+                        requestId = ++this.annotationRequestId; // store in outer scope for finally access
                         await this.api.annotateSample(this.currentImageFilename, className);
                         if (requestId !== this.annotationRequestId) return; // stale response
 


### PR DESCRIPTION
## Summary
- Ensure requestId for keyboard-driven annotation is scoped outside the try block so the `finally` clause can access it without throwing a ReferenceError

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899cec9d374832fa33145acfa20b736