### PR TITLE
Add searchable architecture dropdown for AI training

### DIFF
--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -219,6 +219,19 @@ async def get_training_stats(request: Request):
     return JSONResponse(stats)
 
 
+async def get_architectures(request: Request):
+    """Return available model architectures for the training process."""
+    resnets = ["resnet18", "resnet34"]
+    try:
+        import timm
+
+        models = sorted(timm.list_models())
+    except Exception:
+        models = []
+    architectures = resnets + [m for m in models if m not in resnets]
+    return JSONResponse({"architectures": architectures})
+
+
 async def run_ai(request: Request):
     """Launch the background training process if not already running."""
     global ai_process
@@ -282,6 +295,7 @@ app = Starlette(
         Route("/annotate", handle_annotation, methods=["DELETE"]),
         Route("/stats", get_stats, methods=["GET"]),
         Route("/training_stats", get_training_stats, methods=["GET"]),
+        Route("/architectures", get_architectures, methods=["GET"]),
         Route("/run_ai", run_ai, methods=["POST"]),
         Route("/stop_ai", stop_ai, methods=["POST"]),
         Route("/export_db", export_db, methods=["GET"]),

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -33,7 +33,8 @@
                         <button id="undo-btn" class="undo-btn">Undo (Ctrl+Z/U/Backspace)</button>
                         <button id="export-db-btn" class="export-btn">Export DB (Ctrl+E)</button>
                         <div class="ai-control">
-                                <input id="ai-arch" placeholder="architecture">
+                                <input id="ai-arch" list="arch-options" placeholder="architecture">
+                                <datalist id="arch-options"></datalist>
                                 <input id="ai-sleep" type="number" placeholder="sleep">
                                 <input id="ai-budget" type="number" placeholder="budget">
                                 <input id="ai-resize" type="number" placeholder="resize">

--- a/src/frontend/js/api.js
+++ b/src/frontend/js/api.js
@@ -98,6 +98,13 @@ export class API {
         return await res.json();
     }
 
+    async getArchitectures() {
+        const res = await fetch('/architectures');
+        if (!res.ok) throw new Error('Failed to get architectures');
+        const data = await res.json();
+        return Array.isArray(data.architectures) ? data.architectures : [];
+    }
+
     async runAI(params) {
         const res = await fetch('/run_ai', {
             method: 'POST',

--- a/src/frontend/js/app.js
+++ b/src/frontend/js/app.js
@@ -18,6 +18,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 if (stopBtn) stopBtn.style.display = aiRunning ? 'inline-block' : 'none';
         }
         const archInput = document.getElementById('ai-arch');
+        const archDatalist = document.getElementById('arch-options');
         const sleepInput = document.getElementById('ai-sleep');
         const budgetInput = document.getElementById('ai-budget');
         const resizeInput = document.getElementById('ai-resize');
@@ -69,6 +70,18 @@ document.addEventListener('DOMContentLoaded', async () => {
         // Create the API instance
         const api = new API();
         updateAIButtons();
+        if (archDatalist) {
+                try {
+                        const archs = await api.getArchitectures();
+                        archs.forEach(a => {
+                                const opt = document.createElement('option');
+                                opt.value = a;
+                                archDatalist.appendChild(opt);
+                        });
+                } catch (e) {
+                        console.error('Failed to load architectures:', e);
+                }
+        }
         if (exportDBBtn) {
                 exportDBBtn.addEventListener('click', () => api.exportDB());
         }


### PR DESCRIPTION
## Summary
- Expose `/architectures` endpoint that lists available timm models plus default ResNet options.
- Populate AI control with a searchable datalist of model architectures using the new API.
- Fetch architecture list on load so users can select models instead of typing strings.

## Testing
- `python -m py_compile src/backend/main.py`
- `node --check src/frontend/js/api.js`
- `node --check src/frontend/js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_6899e4a1613c832fb8a3d33f80c869a4