### PR TITLE
Expose configurable preprocessing for fastai trainer

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,8 @@ directory wipes all progress so the app starts from scratch on the next run.
   3. Export the learner to `<db>.pkl` so progress persists across runs.
   4. Predict on remaining unlabeled images and write predictions to DB.
   5. Sleep for a configurable delay and repeat.
+  - Preprocessing options like resize, flip and rotation can be set via `PUT /config` in
+    a `preprocessing` dictionary before launching the trainer.
 
 ## Usage
 1. Start backend: `uvicorn src.backend.main:app`.
@@ -65,7 +67,6 @@ directory wipes all progress so the app starts from scratch on the next run.
 ## next
 - image loader (.zip)
 - implement show -> save -> prefetch pattern
-- user editable preprocessing
 - better model export
 - model inference example
 

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -239,10 +239,13 @@ async def run_ai(request: Request):
         return JSONResponse({"status": "already running"}, status_code=400)
 
     data = await request.json()
-    arch = data.get("architecture", "resnet18")
+    arch = data.get("architecture", config.get("architecture", "resnet18"))
     sleep = int(data.get("sleep", 0))
     budget = int(data.get("budget", 1000))
-    resize = int(data.get("resize", 64))
+    preproc = config.get("preprocessing", {})
+    resize = int(preproc.get("resize", 64))
+    flip = preproc.get("flip", True)
+    max_rotate = float(preproc.get("max_rotate", 10.0))
     cmd = [
         "python",
         "-m",
@@ -256,6 +259,10 @@ async def run_ai(request: Request):
         "--resize",
         str(resize),
     ]
+    if not flip:
+        cmd.append("--no-flip")
+    if max_rotate != 10.0:
+        cmd.extend(["--max-rotate", str(max_rotate)])
     ai_process = subprocess.Popen(cmd)
     return JSONResponse({"status": "started"})
 


### PR DESCRIPTION
## Summary
- allow `/config` to define preprocessing options (resize, flip, max_rotate)
- propagate preprocessing config to `fastai_training`
- document preprocessing configuration

## Testing
- `python -m py_compile src/ml/fastai_training.py src/backend/main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899e65bad64832fa7b8aa2886511df2