### PR TITLE
Handle missing session directory automatically

### DIFF
--- a/src/database/data.py
+++ b/src/database/data.py
@@ -477,6 +477,17 @@ class DatabaseAPI:
         self.conn.execute("PRAGMA journal_mode=WAL;")
         self._create_tables()
 
+    def reconnect(self):
+        """Recreate the database connection if the underlying file was removed."""
+        try:
+            self.conn.close()
+        except Exception:
+            pass
+        os.makedirs(os.path.dirname(self.db_path), exist_ok=True)
+        self.conn = sqlite3.connect(self.db_path)
+        self.conn.execute("PRAGMA journal_mode=WAL;")
+        self._create_tables()
+
     def _create_tables(self):
         cursor = self.conn.cursor()
         cursor.execute(


### PR DESCRIPTION
## Summary
- Reconnect database when the session directory is removed
- Add middleware to rebuild a fresh session DB and reset config/annotation buffer

## Testing
- `python -m py_compile src/backend/main.py src/database/data.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689a00cbe79c832fb865c3989e1cd3ac