### PR TITLE
Refactor DatabaseAPI to use per-request connections

### DIFF
--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -22,12 +22,12 @@ BASE_DIR = Path(__file__).resolve().parent
 FRONTEND_DIR = BASE_DIR.parent / "frontend"
 
 # Initialize the database
-db = DatabaseAPI()
-if not db.get_samples():
-    db_dict = build_initial_db_dict()
-    validate_db_dict(db_dict)
-    db.set_samples([s["filepath"] for s in db_dict["samples"]])
-config = db.get_config() or {}
+with DatabaseAPI() as db:
+    if not db.get_samples():
+        db_dict = build_initial_db_dict()
+        validate_db_dict(db_dict)
+        db.set_samples([s["filepath"] for s in db_dict["samples"]])
+    config = db.get_config() or {}
 
 # Track the last image served to the client
 last_image_served = None
@@ -63,16 +63,16 @@ for _sig in (signal.SIGINT, signal.SIGTERM):
         pass
 
 
-def create_image_response(image_path):
+def create_image_response(image_path, db):
     """Helper function to create image response with headers"""
     mime_type, _ = mimetypes.guess_type(image_path)
     if mime_type is None:
         mime_type = "application/octet-stream"
-    
+
     # Get label or prediction data
     anns = db.get_annotations(image_path)
     label_ann = next((a for a in anns if a.get('type') == 'label'), None)
-    
+
     headers = {
         "X-Image-Id": str(image_path)  # Always include the image ID
     }
@@ -87,7 +87,7 @@ def create_image_response(image_path):
             headers["X-Label-Class"] = str(pred_ann.get('class', ''))
             headers["X-Label-Source"] = "prediction"
             headers["X-Label-Probability"] = str(pred_ann.get('probability', ''))
-    
+
     global last_image_served
     last_image_served = str(image_path)
 
@@ -97,11 +97,12 @@ def create_image_response(image_path):
 async def get_sample_by_id(request):
     # Get id from query parameter, must be in the database
     id_param = request.query_params.get("id")
-    all_images = db.get_samples()
-    if id_param not in all_images:
-        # this check is important, without it the client can access any file in the system
-        raise ValueError(f"Image with id '{id_param}' not found.")
-    return create_image_response(id_param)
+    with DatabaseAPI() as db:
+        all_images = db.get_samples()
+        if id_param not in all_images:
+            # this check is important, without it the client can access any file in the system
+            raise ValueError(f"Image with id '{id_param}' not found.")
+        return create_image_response(id_param, db)
 
 
 
@@ -109,95 +110,98 @@ async def get_next_sample(request):
     current_id = request.query_params.get("current_id")
     strategy = request.query_params.get("strategy", "least_confident_minority")
 
-    # Sequential strategy (existing behaviour)
-    def sequential_next():
-        filepath = db.get_next_unlabeled_sequential(current_id)
-        if filepath:
-            return create_image_response(filepath)
-        return JSONResponse({"error": "No unlabeled images available"}, status_code=404)
+    with DatabaseAPI() as db:
+        # Sequential strategy (existing behaviour)
+        def sequential_next():
+            filepath = db.get_next_unlabeled_sequential(current_id)
+            if filepath:
+                return create_image_response(filepath, db)
+            return JSONResponse({"error": "No unlabeled images available"}, status_code=404)
 
-    if strategy == "sequential":
-        return sequential_next()
-    if strategy == "least_confident_minority":
-        filepath = db.get_next_unlabeled_default(current_id)
-        if filepath:
-            return create_image_response(filepath)
-        return sequential_next()
-    if strategy == "last_class":
-        if annotation_buffer:
-            target_class = annotation_buffer[-1][1]
-            filepath = db.get_next_unlabeled_for_class(target_class, current_id)
+        if strategy == "sequential":
+            return sequential_next()
+        if strategy == "least_confident_minority":
+            filepath = db.get_next_unlabeled_default(current_id)
             if filepath:
-                return create_image_response(filepath)
-        # Fallbacks if no sample found for last class
-        filepath = db.get_next_unlabeled_default(current_id)
-        if filepath:
-            return create_image_response(filepath)
-        return sequential_next()
-    if strategy == "specific_class":
-        target_class = request.query_params.get("class")
-        if target_class:
-            filepath = db.get_next_unlabeled_for_class(target_class, current_id)
+                return create_image_response(filepath, db)
+            return sequential_next()
+        if strategy == "last_class":
+            if annotation_buffer:
+                target_class = annotation_buffer[-1][1]
+                filepath = db.get_next_unlabeled_for_class(target_class, current_id)
+                if filepath:
+                    return create_image_response(filepath, db)
+            # Fallbacks if no sample found for last class
+            filepath = db.get_next_unlabeled_default(current_id)
             if filepath:
-                return create_image_response(filepath)
-        filepath = db.get_next_unlabeled_default(current_id)
-        if filepath:
-            return create_image_response(filepath)
-        return sequential_next()
-    return JSONResponse({"error": "Invalid strategy"}, status_code=400)
+                return create_image_response(filepath, db)
+            return sequential_next()
+        if strategy == "specific_class":
+            target_class = request.query_params.get("class")
+            if target_class:
+                filepath = db.get_next_unlabeled_for_class(target_class, current_id)
+                if filepath:
+                    return create_image_response(filepath, db)
+            filepath = db.get_next_unlabeled_default(current_id)
+            if filepath:
+                return create_image_response(filepath, db)
+            return sequential_next()
+        return JSONResponse({"error": "Invalid strategy"}, status_code=400)
 
 
 async def handle_annotation(request: Request):
     global annotation_buffer
-    if request.method == "POST":
-        data = await request.json()
-        filepath = data.get("filepath")
-        class_name = data.get("class")
-        if not filepath or not isinstance(class_name, str):
-            return JSONResponse({"error": "Missing or invalid 'filepath' or 'class'"}, status_code=400)
-        # Ensure the filepath exists in the database and on disk
-        if filepath not in db.get_samples() or not os.path.isfile(filepath):
-            return JSONResponse({"error": "Filepath not found"}, status_code=404)
-        # Write annotation to DB
-        db.save_label_annotation(filepath, class_name)
+    with DatabaseAPI() as db:
+        if request.method == "POST":
+            data = await request.json()
+            filepath = data.get("filepath")
+            class_name = data.get("class")
+            if not filepath or not isinstance(class_name, str):
+                return JSONResponse({"error": "Missing or invalid 'filepath' or 'class'"}, status_code=400)
+            # Ensure the filepath exists in the database and on disk
+            if filepath not in db.get_samples() or not os.path.isfile(filepath):
+                return JSONResponse({"error": "Filepath not found"}, status_code=404)
+            # Write annotation to DB
+            db.save_label_annotation(filepath, class_name)
 
-        # Store in recent annotation buffer
-        annotation_buffer.append((filepath, class_name))
+            # Store in recent annotation buffer
+            annotation_buffer.append((filepath, class_name))
 
-        # Accuracy tracking: check prediction
-        preds = db.get_predictions(filepath)
-        pred_ann = next((p for p in preds if p.get('type') == 'label' and p.get('probability') is not None), None)
-        if pred_ann:
-            was_correct = str(pred_ann.get("class")) == str(class_name)
-            db.log_accuracy(was_correct)
-        return JSONResponse({"status": "ok"})
-    elif request.method == "DELETE":
-        data = await request.json()
-        filepath = data.get("filepath")
-        if not filepath:
-            return JSONResponse({"error": "Missing 'filepath'"}, status_code=400)
-        if filepath not in db.get_samples() or not os.path.isfile(filepath):
-            return JSONResponse({"error": "Filepath not found"}, status_code=404)
-        db.delete_label_annotation(filepath)
-        # Remove any occurrences from the annotation buffer
-        annotation_buffer = deque(
-            [p for p in annotation_buffer if p[0] != filepath],
-            maxlen=ANNOTATION_BUFFER_SIZE,
-        )
-        return JSONResponse({"status": "deleted"})
-    else:
-        return JSONResponse({"error": "Method not allowed"}, status_code=405)
+            # Accuracy tracking: check prediction
+            preds = db.get_predictions(filepath)
+            pred_ann = next((p for p in preds if p.get('type') == 'label' and p.get('probability') is not None), None)
+            if pred_ann:
+                was_correct = str(pred_ann.get("class")) == str(class_name)
+                db.log_accuracy(was_correct)
+            return JSONResponse({"status": "ok"})
+        elif request.method == "DELETE":
+            data = await request.json()
+            filepath = data.get("filepath")
+            if not filepath:
+                return JSONResponse({"error": "Missing 'filepath'"}, status_code=400)
+            if filepath not in db.get_samples() or not os.path.isfile(filepath):
+                return JSONResponse({"error": "Filepath not found"}, status_code=404)
+            db.delete_label_annotation(filepath)
+            # Remove any occurrences from the annotation buffer
+            annotation_buffer = deque(
+                [p for p in annotation_buffer if p[0] != filepath],
+                maxlen=ANNOTATION_BUFFER_SIZE,
+            )
+            return JSONResponse({"status": "deleted"})
+        else:
+            return JSONResponse({"error": "Method not allowed"}, status_code=405)
 
 async def get_accuracy_stats(request: Request):
-    stats = db.get_accuracy_counts()
-    tries = stats["tries"]
-    correct = stats["correct"]
-    accuracy = (correct / tries) if tries > 0 else None
-    return JSONResponse({
-        "tries": tries,
-        "correct": correct,
-        "accuracy": accuracy
-    })
+    with DatabaseAPI() as db:
+        stats = db.get_accuracy_counts()
+        tries = stats["tries"]
+        correct = stats["correct"]
+        accuracy = (correct / tries) if tries > 0 else None
+        return JSONResponse({
+            "tries": tries,
+            "correct": correct,
+            "accuracy": accuracy
+        })
 
 async def put_config(request: Request):
     data = await request.json()
@@ -212,23 +216,26 @@ async def put_config(request: Request):
 
     # Merge and save the config in the database
     config.update(data)
-    db.update_config(config)
+    with DatabaseAPI() as db:
+        db.update_config(config)
     return JSONResponse({"status": "Config saved successfully"})
 
 async def get_config(request: Request):
-    cfg = db.get_config()
+    with DatabaseAPI() as db:
+        cfg = db.get_config()
     # Treat an empty configuration as a valid result instead of returning 404.
     # The database returns an empty dict when no config has been saved yet, so
     # simply return that to the client.
     return JSONResponse(cfg)
 
 async def get_stats(request: Request):
-    annotated = db.count_labeled_samples()
-    total = db.count_total_samples()
-    ann_counts = db.get_annotation_counts()
     pct_param = request.query_params.get("pct")
     pct = float(pct_param) if pct_param is not None else 100.0
-    stats = db.get_accuracy_counts() if pct >= 100 else db.get_accuracy_recent_pct(pct)
+    with DatabaseAPI() as db:
+        annotated = db.count_labeled_samples()
+        total = db.count_total_samples()
+        ann_counts = db.get_annotation_counts()
+        stats = db.get_accuracy_counts() if pct >= 100 else db.get_accuracy_recent_pct(pct)
     tries = stats["tries"]
     correct = stats["correct"]
     accuracy = (correct / tries) if tries > 0 else None
@@ -247,7 +254,8 @@ async def get_stats(request: Request):
     )
 
 async def get_training_stats(request: Request):
-    stats = db.get_training_stats()
+    with DatabaseAPI() as db:
+        stats = db.get_training_stats()
     return JSONResponse(stats)
 
 
@@ -326,7 +334,8 @@ async def stop_ai(request: Request):
 async def export_db(request: Request):
     tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".json")
     tmp.close()
-    db.export_db_as_json(tmp.name)
+    with DatabaseAPI() as db:
+        db.export_db_as_json(tmp.name)
     return FileResponse(
         tmp.name,
         media_type="application/json",

--- a/src/database/data.py
+++ b/src/database/data.py
@@ -472,10 +472,17 @@ class DatabaseAPI:
         else:
             os.makedirs(os.path.dirname(db_path), exist_ok=True)
         self.db_path = db_path
+        self.conn = None
+
+    def __enter__(self):
         self.conn = sqlite3.connect(self.db_path)
         # Enable WAL mode for better concurrency
         self.conn.execute("PRAGMA journal_mode=WAL;")
         self._create_tables()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.close()
 
     def _create_tables(self):
         cursor = self.conn.cursor()
@@ -546,7 +553,9 @@ class DatabaseAPI:
         self.conn.commit()
 
     def close(self):
-        self.conn.close()
+        if self.conn:
+            self.conn.close()
+            self.conn = None
 
     def get_annotation_counts(self):
         """Return a dict mapping label class to number of annotations."""


### PR DESCRIPTION
## Summary
- open and close SQLite connections via `DatabaseAPI` context manager
- use a fresh `DatabaseAPI` session inside each backend request handler
- adjust training loop to work with context-managed database sessions

## Testing
- `python -m py_compile src/database/data.py src/backend/main.py src/ml/fastai_training.py`


------
https://chatgpt.com/codex/tasks/task_e_689a052bddc4832fa382ae5a0571818e