### PR TITLE
feat: serve API under /api

### DIFF
--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -333,8 +333,7 @@ async def export_db(request: Request):
         filename="db_export.json",
         background=BackgroundTask(lambda: os.remove(tmp.name)),
     )
-
-app = Starlette(
+api = Starlette(
     routes=[
         Route("/config", put_config, methods=["PUT"]),
         Route("/config", get_config, methods=["GET"]),
@@ -350,6 +349,9 @@ app = Starlette(
         Route("/export_db", export_db, methods=["GET"]),
     ]
 )
+
+app = Starlette()
+app.mount("/api", api)
 app.mount("/", StaticFiles(directory=FRONTEND_DIR, html=True), name="frontend")
 
 


### PR DESCRIPTION
## Summary
- mount API endpoints under `/api`
- serve frontend static files at root

## Testing
- `python -m py_compile src/backend/main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a0803e3a8832fa2dca9185352daaf