### PR TITLE
refactor: centralize learner init

### DIFF
--- a/src/ml/fastai_training.py
+++ b/src/ml/fastai_training.py
@@ -61,11 +61,16 @@ except ModuleNotFoundError:  # script run from repo root
 # helpers
 # ---------------------------------------------------------------------------
 
+
 def _gather_training_items(db: DatabaseAPI) -> List[Tuple[str, str]]:
     """Latest *label* per image as ``(filepath, class)`` list."""
     items: List[Tuple[str, str]] = []
     for fp in db.get_samples():
-        labels = [a for a in db.get_annotations(fp) if a.get("type") == "label" and a.get("class")]
+        labels = [
+            a
+            for a in db.get_annotations(fp)
+            if a.get("type") == "label" and a.get("class")
+        ]
         if labels:
             latest = max(labels, key=lambda a: a.get("timestamp", 0))
             items.append((fp, latest["class"]))
@@ -120,8 +125,48 @@ def _predict_subset(db: DatabaseAPI, learner, unlabeled: List[str], budget: int)
 
 
 # ---------------------------------------------------------------------------
+# learner management
+# ---------------------------------------------------------------------------
+
+
+def _init_or_update_learner(dls, model_arch, model_path: Path, existing_learner):
+    """Return a ``Learner`` initialized or updated for the current cycle.
+
+    Responsibilities:
+    * Load a previously exported learner from ``model_path`` when available.
+    * Re‑initialize the model if the set of classes has changed since the last
+      cycle.
+    * Attach fresh ``DataLoaders`` to keep the dataset in sync.
+    """
+    new_classes = set(dls.vocab)
+    learner = existing_learner
+    if learner is None:
+        if model_path.exists():
+            try:
+                learner = load_learner(model_path)
+                learner.dls = dls
+            except Exception as e:
+                print(f"[WARN] Failed to load exported learner: {e}")
+                learner = vision_learner(dls, model_arch, metrics=accuracy)
+        else:
+            learner = vision_learner(dls, model_arch, metrics=accuracy)
+    else:
+        current_classes = set(learner.dls.vocab)
+        if new_classes != current_classes:
+            print(
+                f"[INFO] Detected class change {current_classes} -> {new_classes}; resetting model"
+            )
+            learner = vision_learner(dls, model_arch, metrics=accuracy)
+        else:
+            # re‑attach fresh DataLoaders to keep dataset up‑to‑date
+            learner.dls = dls
+    return learner
+
+
+# ---------------------------------------------------------------------------
 # main loop
 # ---------------------------------------------------------------------------
+
 
 def _run_forever(
     db_path: str | None,
@@ -142,7 +187,9 @@ def _run_forever(
     signal.signal(signal.SIGINT, _exit_handler)
     signal.signal(signal.SIGTERM, _exit_handler)
 
-    model_arch = resnet18 if arch == "resnet18" else (resnet34 if arch == "resnet34" else arch)
+    model_arch = (
+        resnet18 if arch == "resnet18" else (resnet34 if arch == "resnet34" else arch)
+    )
     learner = None  # will lazily instantiate when we first have data
     model_path = Path(db.db_path).with_name("checkpoint.pkl")
     cycle = 0
@@ -159,27 +206,7 @@ def _run_forever(
             paths, labels = zip(*train_items)
             dls = _build_dls(paths, labels, resize, flip, max_rotate)
 
-            new_classes = set(dls.vocab)
-            if learner is None:
-                if model_path.exists():
-                    try:
-                        learner = load_learner(model_path)
-                        learner.dls = dls
-                    except Exception as e:
-                        print(f"[WARN] Failed to load exported learner: {e}")
-                        learner = vision_learner(dls, model_arch, metrics=accuracy)
-                else:
-                    learner = vision_learner(dls, model_arch, metrics=accuracy)
-            else:
-                current_classes = set(learner.dls.vocab)
-                if new_classes != current_classes:
-                    print(
-                        f"[INFO] Detected class change {current_classes} -> {new_classes}; resetting model"
-                    )
-                    learner = vision_learner(dls, model_arch, metrics=accuracy)
-                else:
-                    # re‑attach fresh DataLoaders to keep dataset up‑to‑date
-                    learner.dls = dls
+            learner = _init_or_update_learner(dls, model_arch, model_path, learner)
 
             t0 = time.time()
             learner.fit(1)
@@ -189,7 +216,11 @@ def _run_forever(
                 valid_res = learner.validate()
                 valid_loss = float(valid_res[0]) if len(valid_res) > 0 else None
                 accuracy_val = float(valid_res[1]) if len(valid_res) > 1 else None
-                train_loss = float(learner.recorder.losses[-1]) if learner.recorder.losses else None
+                train_loss = (
+                    float(learner.recorder.losses[-1])
+                    if learner.recorder.losses
+                    else None
+                )
             except Exception:
                 train_loss = valid_loss = accuracy_val = None
 
@@ -219,13 +250,22 @@ def _run_forever(
 # CLI
 # ---------------------------------------------------------------------------
 
+
 def main() -> None:
     p = argparse.ArgumentParser()
     p.add_argument("--db", "-d", help="Path to annotation SQLite db", default=None)
     p.add_argument("--arch", "-a", default="resnet18", help="network arch")
     p.add_argument("--sleep", "-s", type=int, default=0, help="Seconds between cycles")
-    p.add_argument("--budget", "-b", type=int, default=1000, help="Predictions per cycle")
-    p.add_argument("--resize", "-r", type=int, default=64, help="Resize dimension for training images")
+    p.add_argument(
+        "--budget", "-b", type=int, default=1000, help="Predictions per cycle"
+    )
+    p.add_argument(
+        "--resize",
+        "-r",
+        type=int,
+        default=64,
+        help="Resize dimension for training images",
+    )
     p.add_argument(
         "--no-flip",
         action="store_false",
@@ -241,7 +281,15 @@ def main() -> None:
     p.set_defaults(flip=True)
     args = p.parse_args()
 
-    _run_forever(args.db, args.arch, args.sleep, args.budget, args.resize, args.flip, args.max_rotate)
+    _run_forever(
+        args.db,
+        args.arch,
+        args.sleep,
+        args.budget,
+        args.resize,
+        args.flip,
+        args.max_rotate,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `_init_or_update_learner` helper to load checkpoints, reset on class changes, and refresh dataloaders
- use helper in `_run_forever` for cleaner learner management

## Testing
- `python -m black --check src/ml/fastai_training.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a07ae7e70832f8b573fc8c5177428