### PR TITLE
Adapt fastai trainer to new backend config and run flag

### DIFF
--- a/src/ml/fastai_training.py
+++ b/src/ml/fastai_training.py
@@ -9,7 +9,7 @@ Cycle logic
 1. Re‑scan DB → build/refresh ``DataLoaders`` from latest *label* annotations.
 2. Fit the existing learner **one epoch** (weights accumulate over cycles).
 3. Measure epoch wall‑clock time *T* → predict on ``budget = 2 × T`` *unlabeled*
-   images; write predictions via ``DatabaseAPI.set_predictions``.
+   images; write predictions via the database API.
 4. Sleep and repeat.
 
 Model size flag
@@ -28,7 +28,6 @@ The process handles Ctrl‑C/SIGTERM gracefully.
 from __future__ import annotations
 
 import argparse
-import random
 import signal
 import sys
 import time
@@ -50,11 +49,11 @@ from fastai.vision.all import (
 
 # ––– local –––
 try:
-    from src.database.data import DatabaseAPI
+    from src.new_backend import db as backend_db
 except ModuleNotFoundError:  # script run from repo root
     _root = Path(__file__).resolve().parents[2]
     sys.path.append(str(_root))
-    from database.data import DatabaseAPI  # type: ignore
+    from new_backend import db as backend_db  # type: ignore
 
 
 # ---------------------------------------------------------------------------
@@ -62,18 +61,15 @@ except ModuleNotFoundError:  # script run from repo root
 # ---------------------------------------------------------------------------
 
 
-def _gather_training_items(db: DatabaseAPI) -> List[Tuple[str, str]]:
+def _gather_training_items(samples: Sequence[dict]) -> List[Tuple[str, str]]:
     """Latest *label* per image as ``(filepath, class)`` list."""
     items: List[Tuple[str, str]] = []
-    for fp in db.get_samples():
-        labels = [
-            a
-            for a in db.get_annotations(fp)
-            if a.get("type") == "label" and a.get("class")
-        ]
+    for s in samples:
+        anns = backend_db.get_annotations(s["id"])
+        labels = [a for a in anns if a.get("type") == "label" and a.get("class")]
         if labels:
             latest = max(labels, key=lambda a: a.get("timestamp", 0))
-            items.append((fp, latest["class"]))
+            items.append((s["sample_filepath"], latest["class"]))
     return items
 
 
@@ -98,22 +94,22 @@ def _build_dls(
     )
 
 
-def _predict_subset(db: DatabaseAPI, learner, unlabeled: List[str], budget: int) -> int:
-    """Predict for *budget* images, return #predicted."""
+def _predict_subset(learner, unlabeled: List[dict], budget: int) -> int:
+    """Predict for *budget* samples, return #predicted."""
     if budget <= 0 or not unlabeled:
         return 0
     subset = unlabeled[:budget]
-    # Use fastai's dataloader to perform batched predictions for efficiency
-    dl = learner.dls.test_dl(subset, bs=learner.dls.bs)
+    dl = learner.dls.test_dl(
+        [s["sample_filepath"] for s in subset], bs=learner.dls.bs
+    )
     preds, _, decoded = learner.get_preds(dl=dl, with_decoded=True)
 
-    for fp, pred_tensor, pred_class in zip(subset, preds, decoded):
+    for sample, pred_tensor, pred_class in zip(subset, preds, decoded):
         pred_idx = int(pred_tensor.argmax())
-        db.set_predictions(
-            fp,
+        backend_db.set_predictions(
+            sample["id"],
             [
                 {
-                    "sample_filepath": fp,
                     "type": "label",
                     "class": str(learner.dls.vocab[pred_class.item()]),
                     "probability": float(pred_tensor[pred_idx]),
@@ -168,75 +164,102 @@ def _init_or_update_learner(dls, model_arch, model_path: Path, existing_learner)
 # ---------------------------------------------------------------------------
 
 
-def _run_forever(
-    db_path: str | None,
-    arch: str,
-    sleep_s: int,
-    budget: int,
-    resize: int,
-    flip: bool,
-    max_rotate: float,
-) -> None:
-    with DatabaseAPI(db_path) as db:
+def _run_forever(flip: bool, max_rotate: float) -> None:
 
-        def _exit_handler(*_):
-            print("\n[INFO] Exiting…")
-            sys.exit(0)
+    def _exit_handler(*_):
+        print("\n[INFO] Exiting…")
+        sys.exit(0)
 
-        signal.signal(signal.SIGINT, _exit_handler)
-        signal.signal(signal.SIGTERM, _exit_handler)
+    signal.signal(signal.SIGINT, _exit_handler)
+    signal.signal(signal.SIGTERM, _exit_handler)
 
-        model_arch = resnet18 if arch == "resnet18" else (resnet34 if arch == "resnet34" else arch)
-        learner = None  # will lazily instantiate when we first have data
-        model_path = Path(db.db_path).with_name("checkpoint.pkl")
-        cycle = 0
+    learner = None
+    model_path = Path(backend_db.DB_PATH).with_name("checkpoint.pkl")
+    prev_config: dict | None = None
+    cycle = 0
 
-        while True:
-            cycle += 1
+    while True:
+        try:
+            config = backend_db.get_config()
+        except Exception as e:
+            print(f"[ERR] failed to load config: {e}", file=sys.stderr)
+            time.sleep(5)
+            continue
+
+        if prev_config != config:
+            if prev_config is not None:
+                print("[INFO] Config changed; resetting learner")
+            learner = None
+            cycle = 0
             try:
-                train_items = _gather_training_items(db)
-                if not train_items:
-                    print("[WARN] No label annotations available — sleeping…")
-                    time.sleep(max(1, sleep_s))
-                    continue
+                if model_path.exists():
+                    model_path.unlink()
+            except Exception:
+                pass
+            prev_config = config
 
-                paths, labels = zip(*train_items)
-                dls = _build_dls(paths, labels, resize, flip, max_rotate)
+        sleep_s = config.get("sleep", 5) or 5
+        if not config.get("ai_should_be_run", False):
+            print("[INFO] Run flag disabled — sleeping…")
+            time.sleep(max(1, sleep_s))
+            continue
 
-                learner = _init_or_update_learner(dls, model_arch, model_path, learner)
+        arch = config.get("architecture", "resnet18")
+        model_arch = resnet18 if arch == "resnet18" else (
+            resnet34 if arch == "resnet34" else arch
+        )
+        budget = config.get("budget", 1000)
+        resize = config.get("resize", 64)
 
-                t0 = time.time()
-                learner.fit(1)
-                epoch_time = time.time() - t0
-
-                try:
-                    valid_res = learner.validate()
-                    valid_loss = float(valid_res[0]) if len(valid_res) > 0 else None
-                    accuracy_val = float(valid_res[1]) if len(valid_res) > 1 else None
-                    train_loss = float(learner.recorder.losses[-1]) if learner.recorder.losses else None
-                except Exception:
-                    train_loss = valid_loss = accuracy_val = None
-
-                db.add_training_stat(cycle, train_loss, valid_loss, accuracy_val)
-                # Export learner after each epoch so it can be reloaded easily
-                try:
-                    learner.export(model_path)
-                except Exception as e:
-                    print(f"[WARN] Failed to export learner: {e}")
-
-                labeled_set = set(paths)
-                unlabeled = [fp for fp in db.get_samples() if fp not in labeled_set]
-                predicted_n = _predict_subset(db, learner, unlabeled, budget)
-
-                print(
-                    f"[cycle {cycle}] epoch {epoch_time:.1f}s — predicted {predicted_n}/{len(unlabeled)} "
-                    f"unlabeled — sleeping {sleep_s}s"
-                )
-            except Exception as e:
-                print(f"[ERR][cycle {cycle}] {e}", file=sys.stderr)
-            finally:
-                torch.cuda.empty_cache()
+        try:
+            samples = backend_db.get_all_samples()
+            train_items = _gather_training_items(samples)
+            if not train_items:
+                print("[WARN] No label annotations available — sleeping…")
                 time.sleep(max(1, sleep_s))
+                continue
+
+            paths, labels = zip(*train_items)
+            dls = _build_dls(paths, labels, resize, flip, max_rotate)
+            learner = _init_or_update_learner(dls, model_arch, model_path, learner)
+
+            t0 = time.time()
+            learner.fit(1)
+            epoch_time = time.time() - t0
+
+            try:
+                valid_res = learner.validate()
+                valid_loss = float(valid_res[0]) if len(valid_res) > 0 else None
+                accuracy_val = float(valid_res[1]) if len(valid_res) > 1 else None
+                train_loss = (
+                    float(learner.recorder.losses[-1])
+                    if learner.recorder.losses
+                    else None
+                )
+            except Exception:
+                train_loss = valid_loss = accuracy_val = None
+
+            backend_db.store_training_stats(cycle, train_loss, valid_loss, accuracy_val)
+
+            try:
+                learner.export(model_path)
+            except Exception as e:
+                print(f"[WARN] Failed to export learner: {e}")
+
+            labeled_set = set(paths)
+            unlabeled = [s for s in samples if s["sample_filepath"] not in labeled_set]
+            predicted_n = _predict_subset(learner, unlabeled, budget)
+
+            print(
+                f"[cycle {cycle}] epoch {epoch_time:.1f}s — predicted {predicted_n}/{len(unlabeled)} "
+                f"unlabeled — sleeping {sleep_s}s"
+            )
+            cycle += 1
+        except Exception as e:
+            print(f"[ERR][cycle {cycle}] {e}", file=sys.stderr)
+        finally:
+            torch.cuda.empty_cache()
+            time.sleep(max(1, sleep_s))
 
 
 # ---------------------------------------------------------------------------
@@ -247,18 +270,6 @@ def _run_forever(
 def main() -> None:
     p = argparse.ArgumentParser()
     p.add_argument("--db", "-d", help="Path to annotation SQLite db", default=None)
-    p.add_argument("--arch", "-a", default="resnet18", help="network arch")
-    p.add_argument("--sleep", "-s", type=int, default=0, help="Seconds between cycles")
-    p.add_argument(
-        "--budget", "-b", type=int, default=1000, help="Predictions per cycle"
-    )
-    p.add_argument(
-        "--resize",
-        "-r",
-        type=int,
-        default=64,
-        help="Resize dimension for training images",
-    )
     p.add_argument(
         "--no-flip",
         action="store_false",
@@ -274,12 +285,10 @@ def main() -> None:
     p.set_defaults(flip=True)
     args = p.parse_args()
 
+    if args.db:
+        backend_db.DB_PATH = args.db
+
     _run_forever(
-        args.db,
-        args.arch,
-        args.sleep,
-        args.budget,
-        args.resize,
         args.flip,
         args.max_rotate,
     )


### PR DESCRIPTION
## Summary
- integrate fastai trainer with new backend database module
- check database config each cycle to pause/resume based on `ai_should_be_run` and reset on config changes
- add database helpers for listing samples and storing predictions

## Testing
- `python -m py_compile src/new_backend/db.py src/ml/fastai_training.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4cf5f2b74832f989d32e0e78691fb