### PR TITLE
Add script to run training and webapp together

### DIFF
--- a/run_with_training.sh
+++ b/run_with_training.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Start the FastAI training script in the background
+python -m src.ml.fastai_training &
+TRAIN_PID=$!
+
+cleanup() {
+  if kill -0 "$TRAIN_PID" 2>/dev/null; then
+    echo "Stopping training process $TRAIN_PID"
+    kill "$TRAIN_PID" 2>/dev/null || true
+    wait "$TRAIN_PID" 2>/dev/null || true
+  fi
+}
+
+trap cleanup EXIT INT TERM
+
+# Run the web application via gunicorn
+# Bind to port 8001 to match project defaults
+exec gunicorn -k uvicorn.workers.UvicornWorker -b 0.0.0.0:8001 src.backend.main:app


### PR DESCRIPTION
## Summary
- Add `run_with_training.sh` to launch FastAI training in the background while running the Gunicorn web app, and clean up the training process on exit.

## Testing
- `bash -n run_with_training.sh`
- `shellcheck run_with_training.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a705ef4710832f94abf280fc0cd734