### PR TITLE
Include training stats in stats endpoint

### DIFF
--- a/src/frontend/js/views/trainingCurveView.js
+++ b/src/frontend/js/views/trainingCurveView.js
@@ -8,8 +8,9 @@ export class TrainingCurveView {
     if (!this.canvas) return;
     const requestId = ++this.trainingRequestId;
     try {
-      const data = await this.api.getTrainingStats();
+      const stats = await this.api.getStats();
       if (requestId !== this.trainingRequestId) return;
+      const data = stats.training_stats || [];
       const points = data.map(d => ({ x: d.epoch, y: d.accuracy ?? 0 }));
       drawCurve(this.canvas, points);
     } catch (e) {


### PR DESCRIPTION
## Summary
- update training curve view to fetch training stats from general stats API
- augment backend stats endpoint to return training metrics

## Testing
- `python -m py_compile src/backend/main.py`
- `node --check src/frontend/js/views/trainingCurveView.js`


------
https://chatgpt.com/codex/tasks/task_e_68a7067c78c8832f8c46f1a7a5886d3d