### PR TITLE
Add getArchitectures API helper

### DIFF
--- a/src/frontend/js/api.js
+++ b/src/frontend/js/api.js
@@ -54,6 +54,11 @@ export class API {
         if (!res.ok) throw new Error('Failed to get config');
         return await res.json();
     }
+
+    async getArchitectures() {
+        const cfg = await this.getConfig();
+        return Array.isArray(cfg.available_architectures) ? cfg.available_architectures : [];
+    }
     async updateConfig(config) {
         // Map frontend camelCase flag to backend snake_case if present
         const payload = { ...config };


### PR DESCRIPTION
## Summary
- add `getArchitectures` method to frontend API
- enable AI controls to load architecture options from config when not pre-populated

## Testing
- `node --check src/frontend/js/api.js`
- `node --check src/frontend/js/views/aiControlsView.js`


------
https://chatgpt.com/codex/tasks/task_e_68a70bbbd290832f8a700c5a3db2835b