### PR TITLE
refactor: simplify strategy params retrieval

### DIFF
--- a/src/frontend/js/app.js
+++ b/src/frontend/js/app.js
@@ -80,7 +80,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         function getStrategyParams() {
                 // Determine strategy & pick parameters from StrategyView state.
                 // Silent bug fix: strategy selection in UI was never applied to image fetching.
-                if (!strategyView) return { strategy: null, pick: null };
                 const strategy = strategyView.currentStrategy || null;
                 let pick = null;
                 if (strategy === 'specific_class') {


### PR DESCRIPTION
## Summary
- remove redundant null check in `getStrategyParams`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a70d299e54832fade698b9776a7c15