### PR TITLE
Ensure configUpdated reflects frontend-backend sync

### DIFF
--- a/src/frontend/js/app.js
+++ b/src/frontend/js/app.js
@@ -74,7 +74,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         async function updateConfigIfNeeded() {
                 if (state.configUpdated) {
                         await api.updateConfig(state.config);
-                        state.configUpdated = false;  // this means frontend config state has been modified w.r.t. the backend's
+                        state.configUpdated = false;  // config synchronized with backend
                 }
         }
         function getStrategyParams() {
@@ -113,7 +113,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                                         available_architectures: cfg.available_architectures || []
                                 };
                         }
-                        state.configUpdated = false;
+                        state.configUpdated = false; // config synchronized with backend
                 } catch (e) {
                         console.error('Failed to load config from server:', e);
                 }

--- a/src/frontend/js/views/aiControlsView.js
+++ b/src/frontend/js/views/aiControlsView.js
@@ -34,6 +34,7 @@ export class AIControlsView {
       this.checkbox.addEventListener('change', () => {
         this.state.aiRunning = this.checkbox.checked;
         this.state.config.aiShouldBeRun = this.state.aiRunning;
+        this.state.configUpdated = true;
         // If turning OFF (unchecked), immediately persist only the flag
         // If turning ON, persist full set of options alongside the flag
         if (!this.state.aiRunning) {
@@ -115,8 +116,10 @@ export class AIControlsView {
     // Merge with existing config then send
     const merged = { ...this.state.config, ...partial };
     this.state.config = merged; // keep local copy consistent
+    this.state.configUpdated = true;
     try {
       await this.api.updateConfig(merged);
+      this.state.configUpdated = false;
     } catch (e) {
       console.error('Failed to update AI config:', e);
       if (this.aiStatus) this.aiStatus.textContent = 'Update failed';
@@ -127,6 +130,7 @@ export class AIControlsView {
     // Optional external call to refresh UI with latest config
     if (cfg) {
       this.state.config = { ...this.state.config, ...cfg };
+      this.state.configUpdated = false;
       this._applyConfigToInputs(this.state.config);
     }
     if (this.checkbox) {


### PR DESCRIPTION
## Summary
- mark `state.configUpdated` whenever AI config changes and clear it after persisting via `persistConfig`
- document config synchronization in `updateConfigIfNeeded` and reset flag after loading server config

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a70d85f4a0832f931c79dccd9bc51d