### PR TITLE
Ensure consistent class colors and alphabetical class ordering

### DIFF
--- a/src/frontend/classification/js/app.js
+++ b/src/frontend/classification/js/app.js
@@ -133,7 +133,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                         const cfg = await api.getConfig();
                         if (cfg) {
                                 state.config = {
-                                        classes: cfg.classes || [],
+                                        classes: (cfg.classes || []).sort(),
                                         aiShouldBeRun: cfg.ai_should_be_run || false,
                                         architecture: cfg.architecture || 'resnet18',
                                         budget: cfg.budget || 1000,

--- a/src/frontend/points/js/app.js
+++ b/src/frontend/points/js/app.js
@@ -20,50 +20,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         classColors: new Map(), // Map class names to colors
     };
 
-    // Generate distinct colors for classes
-    function generateClassColor(index) {
-        const colors = [
-            '#0080FF',
-            '#FFFF80',
-            '#000080',
-            '#008080',
-            '#00FF00',
-            '#800000',
-            '#80FFFF',
-            '#0000FF',
-            '#808000',
-            '#8080FF',
-            '#FF0080',
-            '#008000',
-            '#FF8000',
-            '#FFFF00',
-            '#80FF00',
-            '#FF00FF',
-            '#FFFFFF',
-            '#00FF80',
-            '#00FFFF',
-            '#80FF80',
-            '#FF0000',
-            '#808080',
-            '#8000FF',
-            '#FF8080',
-            '#000000',
-            '#FF80FF',
-            '#800080',
-        ];
-        return colors[index % colors.length];
-    }
-
-    // Get color for a class, assigning one if not exists
-    function getClassColor(className) {
-        if (!state.classColors.has(className)) {
-            const classIndex = state.config.classes.indexOf(className);
-            const color = generateClassColor(classIndex);
-            state.classColors.set(className, color);
-        }
-        return state.classColors.get(className);
-    }
-
     // -----------------------------------------------------------
     // ----------  COMPONENTS  -----------------------------------
     // -----------------------------------------------------------
@@ -105,6 +61,13 @@ document.addEventListener('DOMContentLoaded', async () => {
     // Use segmentation-specific architectures for points annotation
     const segmentationArchitectures = ['small', 'small+', 'base', 'large'];
     const aiControlsView = new AIControlsView(api, state, segmentationArchitectures);
+
+    // Utility to retrieve the color for a class from the view so that
+    // all components use the same color palette and assignments.
+    function getClassColor(className) {
+        return classesView.getClassColor(className);
+    }
+
     // -----------------------------------------------------------
     // ----------  ACTIONS  --------------------------------------
     // -----------------------------------------------------------
@@ -203,7 +166,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             const cfg = await api.getConfig();
             if (cfg) {
                 state.config = {
-                    classes: cfg.classes || [],
+                    classes: (cfg.classes || []).sort(),
                     aiShouldBeRun: cfg.ai_should_be_run || false,
                     architecture: cfg.architecture || 'small', // Default to 'small' for segmentation
                     budget: cfg.budget || 1000,
@@ -211,6 +174,9 @@ document.addEventListener('DOMContentLoaded', async () => {
                     resize: cfg.resize || 224,
                     available_architectures: cfg.available_architectures || []
                 };
+                if (state.classColors instanceof Map) {
+                    state.classColors.clear();
+                }
             }
             state.configUpdated = false; // config synchronized with backend
         } catch (e) {

--- a/src/frontend/points/js/views/pointsClassesView.js
+++ b/src/frontend/points/js/views/pointsClassesView.js
@@ -8,21 +8,33 @@ export class PointsClassesView extends ClassesView {
     // Compute a distinct color per class index, stable across renders.
     generateClassColor(index) {
         const colors = [
-            '#FF6B6B', // red
-            '#4ECDC4', // teal
-            '#45B7D1', // blue
-            '#96CEB4', // green
-            '#FFEAA7', // yellow
-            '#DDA0DD', // plum
-            '#98D8C8', // mint
-            '#F7DC6F', // light yellow
-            '#BB8FCE', // light purple
-            '#85C1E9', // light blue
-            '#F8C471', // orange
-            '#82E0AA', // light green
-            '#F1948A', // light red
-            '#85929E', // gray
-            '#D7BDE2', // lavender
+            '#0080FF',
+            '#FFFF80',
+            '#000080',
+            '#008080',
+            '#00FF00',
+            '#800000',
+            '#80FFFF',
+            '#0000FF',
+            '#808000',
+            '#8080FF',
+            '#FF0080',
+            '#008000',
+            '#FF8000',
+            '#FFFF00',
+            '#80FF00',
+            '#FF00FF',
+            '#FFFFFF',
+            '#00FF80',
+            '#00FFFF',
+            '#80FF80',
+            '#FF0000',
+            '#808080',
+            '#8000FF',
+            '#FF8080',
+            '#000000',
+            '#FF80FF',
+            '#800080',
         ];
         return colors[index % colors.length];
     }

--- a/src/frontend/shared/views/classesView.js
+++ b/src/frontend/shared/views/classesView.js
@@ -65,7 +65,10 @@ export class ClassesView {
         this.renderUI();
     }
     setGlobalClasses(classes) {
-        this.state.config.classes = [...classes];
+        this.state.config.classes = [...classes].sort();
+        if (this.state.classColors instanceof Map) {
+            this.state.classColors.clear();
+        }
         this.state.configUpdated = true;
         this.renderUI();
     }
@@ -92,11 +95,18 @@ export class ClassesView {
     async addClass(className) {
         if (!className || this.state.config.classes.includes(className)) return;
         this.state.config.classes.push(className);
+        this.state.config.classes.sort();
+        if (this.state.classColors instanceof Map) {
+            this.state.classColors.clear();
+        }
         this.state.configUpdated = true;
         this.renderUI();
     }
     async removeClass(className) {
         this.state.config.classes = this.state.config.classes.filter(c => c !== className);
+        if (this.state.classColors instanceof Map) {
+            this.state.classColors.clear();
+        }
         this.state.configUpdated = true;
         this.renderUI();
     }


### PR DESCRIPTION
## Summary
- Replace PointsClassesView color palette with preferred hex values for consistent class color mapping

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad877999ac832f88de9cf4d753e635