### PR TITLE
Restore training set and limit inference to filtered samples

### DIFF
--- a/src/ml/dinov3_classification.py
+++ b/src/ml/dinov3_classification.py
@@ -302,6 +302,9 @@ def main() -> None:
 
         print("[DB] Fetching samples…")
         samples = backend_db.get_all_samples()
+        allowed_ids = backend_db.get_sample_ids_for_path_filter(
+            config.get("sample_path_filter")
+        )
         labeled = _gather_latest_labels(samples)
         if not labeled:
             print("[WARN] No label annotations found — pausing 2s…")
@@ -357,7 +360,12 @@ def main() -> None:
 
         # Predict unlabeled using cache too
         labeled_paths = set(fp for _, fp, _ in labeled)
-        unlabeled = [s for s in samples if s["sample_filepath"] not in labeled_paths]
+        unlabeled = [
+            s
+            for s in samples
+            if s["sample_filepath"] not in labeled_paths
+            and (allowed_ids is None or s["id"] in allowed_ids)
+        ]
         if unlabeled:
             subset = unlabeled[: max(0, budget)]
             print(f"[PRED] Predicting {len(subset)}/{len(unlabeled)} unlabeled images…")

--- a/src/ml/fastai_training.py
+++ b/src/ml/fastai_training.py
@@ -230,6 +230,9 @@ def _run_forever(flip: bool, max_rotate: float) -> None:
 
         try:
             samples = backend_db.get_all_samples()
+            allowed_ids = backend_db.get_sample_ids_for_path_filter(
+                config.get("sample_path_filter")
+            )
             train_items = _gather_training_items(samples)
             if not train_items:
                 print("[WARN] No label annotations available — pausing…")
@@ -264,7 +267,12 @@ def _run_forever(flip: bool, max_rotate: float) -> None:
                 print(f"[WARN] Failed to export learner: {e}")
 
             labeled_set = set(paths)
-            unlabeled = [s for s in samples if s["sample_filepath"] not in labeled_set]
+            unlabeled = [
+                s
+                for s in samples
+                if s["sample_filepath"] not in labeled_set
+                and (allowed_ids is None or s["id"] in allowed_ids)
+            ]
             predicted_n = _predict_subset(learner, unlabeled, budget)
 
             print(


### PR DESCRIPTION
## Summary
- restore `db_ml.get_all_samples` to return the full dataset so training continues to see every sample
- add a helper that returns the IDs matched by the configured filepath glob
- restrict inference loops in the FastAI and DINO trainers to the filtered ID set while keeping training data unchanged

## Testing
- python -m compileall src/backend src/ml

------
https://chatgpt.com/codex/tasks/task_e_68d508646ba0832f93605140a812d313