### PR TITLE
Document config filter fields and clarify segmentation point saves

### DIFF
--- a/system_arch/data.md
+++ b/system_arch/data.md
@@ -147,6 +147,8 @@ Represents the single-row app configuration stored in the `config` table and ret
 | `architecture` | string|null | Model architecture name (e.g., `small`, `large`, or a timm model name) | No |
 | `budget` | integer|null | Training or processing budget (app-dependent meaning) | No |
 | `resize` | integer|null | Image resize target (short side) for ML | No |
+| `sample_path_filter` | string|null | Glob-style path filter applied to sample filenames (`null` disables) | No |
+| `sample_path_filter_count` | integer | Number of samples matching the current filter; recomputed on read | No (computed) |
 | `available_architectures` | string[] | Provided by API (computed), not stored in DB | No (computed) |
 | `last_claim_cleanup` | integer|null | Unix seconds of the last opportunistic claim cleanup; backend updates this when running cleanup | No |
 
@@ -158,6 +160,8 @@ Example:
   "architecture": "small",
   "budget": 1000,
   "resize": 1536,
+  "sample_path_filter": "sessionA/*",
+  "sample_path_filter_count": 128,
   "task": "classification",
   "available_architectures": ["resnet18", "resnet34", "...others..."],
   "last_claim_cleanup": 1716227000
@@ -165,6 +169,7 @@ Example:
 ```
 
 Notes
+- `sample_path_filter_count` currently rides along in the config payload for UI convenience; plan to migrate this counter to `/api/stats` in a future cleanup so config stays purely declarative.
 - Coordinate semantics: All coordinates for points and bboxes are integers representing parts per million of the image dimension. `col01`/`width01` are ppm of image width; `row01`/`height01` are ppm of image height. Range: 0..1,000,000.
 - Probabilities: For label predictions, `probability` is an integer ppm (0..1,000,000). ML writers MUST round floats to nearest ppm; readers MUST divide by 1,000,000 when float is needed. Range clamp: [0, 1_000_000].
 - Single source of truth: `sample_filepath` exists only in `samples`. Child tables store `sample_id`. APIs expose the image filepath for user convenience via the `X-Image-Filepath` response header on image endpoints.

--- a/system_arch/frontend.md
+++ b/system_arch/frontend.md
@@ -48,7 +48,7 @@ The frontend keeps a local config mirror that syncs with the backend on specific
 
 - Load on entry: After fetching an image, parse prediction headers (`X-Predictions-*`), then call `GET /api/annotations/{id}` to seed local points. If `X-Predictions-Type=mask`, fetch each mask asset after annotations load.
 - Edit locally: Maintain a per-class list of points; do not write on every edit.
-- Save on leave (API order): On navigation, push pending config if any → `PUT /api/annotations/{id}` with all `{type:"point", col01, row01, [class]}` for the current image (overwrite-by-type semantics; `col01`/`row01` are integers in ppm of image width/height, 0..1,000,000) → proceed to image fetch per the chosen workflow.
+- Save on leave (API order): On navigation, push pending config if any → `PUT /api/annotations/{id}` with all `{type:"point", class, col01, row01}` for the current image (overwrite-by-type semantics; `class` is mandatory for every point; `col01`/`row01` are integers in ppm of image width/height, 0..1,000,000) → proceed to image fetch per the chosen workflow.
 - Overwrite-by-type reminder: The server replaces all existing annotations of any `type` included in the payload for that sample with exactly those provided. To preserve other types, omit them from the payload. Batch and send the complete list for each included `type`; avoid per-edit writes that could unintentionally overwrite concurrent edits.
 - Delete: Use `DELETE /api/annotations/{id}` to delete all annotations for the current image.
 - Rendering note: Apply class colors and composite overlays; resize masks to match the displayed image dimensions before blending.


### PR DESCRIPTION
## Summary
- document the `sample_path_filter` and `sample_path_filter_count` fields in the config table and call out the future relocation of the count to stats
- update the config example payload to include the filter fields for clarity
- clarify that segmentation point saves always send a class when batching points on leave

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d46ec000cc832f922721a77365954d