### PR TITLE
Add mask promotion workflow and persist accepted masks

### DIFF
--- a/src/frontend/segmentation/index.html
+++ b/src/frontend/segmentation/index.html
@@ -33,6 +33,7 @@
                                         Show overlay (M)
                                 </label>
                         </div>
+                        <button id="accept-mask-btn" class="btn" style="margin-bottom: 12px;">Accept Mask Prediction</button>
                         <div class="sample-filter"><label for="sample-filter-input">Sample path filter:</label><input
                                         type="text" id="sample-filter-input" placeholder="e.g. **/front*"
                                         readonly><span id="sample-filter-count"></span></div>

--- a/src/ml/dinov3_training.py
+++ b/src/ml/dinov3_training.py
@@ -74,6 +74,13 @@ except ModuleNotFoundError:  # script run from repo root
     from backend import db_ml as backend_db  # type: ignore
 
 
+# Placeholder for upcoming mask-annotation integration into the training loop.
+def iter_mask_annotations_for_training() -> List[Tuple[int, str]]:
+    """Return mask annotations once mask-based training support is implemented."""
+    # TODO: integrate accepted mask annotations into the DINOv3 segmentation training pipeline.
+    return []
+
+
 # ---------------------------------------------------------------------------
 # image and feature helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- extend annotation schema and backend endpoints to store accepted mask files and expose secure URLs
- add an accept-mask API with overwrite protection and surface annotation masks ahead of predictions
- update the segmentation UI to promote AI masks, disable stale saves, and show saved annotation overlays
- drop in a placeholder hook for future mask-aware training integration

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d46f9a931c832f812a4ca7d584ebcd