### PR TITLE
Add mask annotation toggle and backend deletion endpoint

### DIFF
--- a/src/backend/db.py
+++ b/src/backend/db.py
@@ -832,6 +832,22 @@ def delete_annotations_by_type(sample_id, annotation_type):
         )
         return cursor.rowcount
 
+
+def delete_mask_annotation(sample_id, class_name):
+    """Delete mask annotations for a specific class on a sample."""
+    if not class_name:
+        return 0
+    with _get_conn() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            DELETE FROM annotations
+            WHERE sample_id = ? AND type = 'mask' AND class = ?
+            """,
+            (sample_id, class_name),
+        )
+        return cursor.rowcount
+
 def get_annotation_stats():
     """Returns current annotation statistics including training stats and live accuracy."""
     with _get_conn() as conn:

--- a/src/frontend/segmentation/index.html
+++ b/src/frontend/segmentation/index.html
@@ -33,7 +33,10 @@
                                         Show overlay (M)
                                 </label>
                         </div>
-                        <button id="accept-mask-btn" class="btn" style="margin-bottom: 12px;">Accept Mask Prediction</button>
+                        <label class="mask-annotation-toggle" style="display:flex;align-items:center;gap:6px;margin-bottom:12px;font-size:0.95rem;">
+                                <input type="checkbox" id="mask-annotation-toggle">
+                                Add prediction as annotation
+                        </label>
                         <div class="sample-filter"><label for="sample-filter-input">Sample path filter:</label><input
                                         type="text" id="sample-filter-input" placeholder="e.g. **/front*"
                                         readonly><span id="sample-filter-count"></span></div>

--- a/src/frontend/shared/js/api.js
+++ b/src/frontend/shared/js/api.js
@@ -163,6 +163,25 @@ export class API {
         return data;
     }
 
+    async deleteMaskAnnotation(sampleId, className) {
+        const res = await fetch(`/api/annotations/${sampleId}/mask/${encodeURIComponent(className)}`, {
+            method: 'DELETE'
+        });
+        let data = null;
+        try {
+            data = await res.json();
+        } catch (_) {
+            data = null;
+        }
+        if (!res.ok) {
+            const err = new Error((data && data.error) ? data.error : 'Failed to delete mask annotation');
+            err.status = res.status;
+            err.payload = data;
+            throw err;
+        }
+        return data;
+    }
+
     async getAnnotations(sampleId) {
         const res = await fetch(`/api/annotations/${sampleId}`);
         if (!res.ok) throw new Error('Failed to get annotations');


### PR DESCRIPTION
## Summary
- add a database helper and Flask endpoint to remove stored mask annotations and clean up files
- expose the deletion API to the frontend and update the segmentation page with an "Add prediction as annotation" toggle
- coordinate mask acceptance/removal flows so the checkbox replaces the separate accept button and disables itself while operations run

## Testing
- python -m compileall src/backend

------
https://chatgpt.com/codex/tasks/task_e_68d98c76a634832faa3899c134702b54