### PR TITLE
Add mask-aware DINOv3 training with configurable loss balance

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -49,9 +49,7 @@ and the AI, which is one of the following:
 
 ## to-do
 - check if claimed is removed by time
-- add mask training
-    - add frontend checkbox
-    - make it save the prediction
+- integrate mask training (done)
 - expose way to add more images if needed
 - when removing a class show warning, remove the annotations for that class, and reset the model
 - make using the keyboard easier (should work everywhere in the app)

--- a/src/backend/db_init.py
+++ b/src/backend/db_init.py
@@ -380,7 +380,8 @@ def initialize_database_if_needed(db_path=DB_PATH):
                 resize INTEGER,
                 last_claim_cleanup INTEGER,
                 task TEXT,
-                sample_path_filter TEXT
+                sample_path_filter TEXT,
+                mask_loss_weight REAL
             );
         """
         )
@@ -393,6 +394,8 @@ def initialize_database_if_needed(db_path=DB_PATH):
             cur.execute("ALTER TABLE config ADD COLUMN task TEXT;")
         if "sample_path_filter" not in cols:
             cur.execute("ALTER TABLE config ADD COLUMN sample_path_filter TEXT;")
+        if "mask_loss_weight" not in cols:
+            cur.execute("ALTER TABLE config ADD COLUMN mask_loss_weight REAL;")
         cur.execute("PRAGMA table_info(annotations);")
         ann_cols = {row[1] for row in cur.fetchall()}
         if "mask_path" not in ann_cols:
@@ -510,16 +513,18 @@ def initialize_database_if_needed(db_path=DB_PATH):
                 "last_claim_cleanup": None,
                 "task": None,
                 "sample_path_filter": None,
+                "mask_loss_weight": 1.0,
             }
             cursor.execute(
                 """
                 INSERT INTO config (
                     classes, ai_should_be_run, architecture, budget, resize,
-                    last_claim_cleanup, task, sample_path_filter
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    last_claim_cleanup, task, sample_path_filter, mask_loss_weight
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
-                (json.dumps(default_config["classes"]), int(default_config["ai_should_be_run"]), 
-                 default_config["architecture"], default_config["budget"], 
+                (json.dumps(default_config["classes"]), int(default_config["ai_should_be_run"]),
+                 default_config["architecture"], default_config["budget"],
                  default_config["resize"], default_config["last_claim_cleanup"],
-                 default_config["task"], default_config["sample_path_filter"])
+                 default_config["task"], default_config["sample_path_filter"],
+                 default_config["mask_loss_weight"])
             )

--- a/system_arch/ml.md
+++ b/system_arch/ml.md
@@ -8,9 +8,9 @@
   - Uses fastai ResNet18/34; cycles training and prediction on unlabeled samples
   - Stores label predictions via `set_predictions_batch()`
   - Logs training curves via `store_training_stats()` and saves checkpoint `session/checkpoint.pkl`
-- `src/ml/dinov3_training.py`: point-based segmentation with DINOv3 features
+- `src/ml/dinov3_training.py`: segmentation with DINOv3 features + linear head
   - Loads local DINOv3 hub models; extracts 16×16 patch features
-  - Trains `SGDClassifier` on annotated points, saves `session/dinov3_linear_classifier_seg.pkl`
+  - Trains a 1×1 Conv head on point and mask annotations, saves `session/dinov3_linear_classifier_seg.pkl`
   - Produces per-class masks per image → PNGs in `session/preds/` and DB `predictions(type='mask')`
 
 ### Configuration Fields
@@ -18,6 +18,7 @@
 - `architecture` (str): `resnet18`/`resnet34` for fastai; `small`/`large` for DINOv3
 - `budget` (int): max items to predict per cycle
 - `resize` (int): image resize (fastai: shorter side; DINOv3: padded canvas size)
+- `mask_loss_weight` (float): balance between mask loss and point loss during segmentation training
 
 ### Data Exchange
 - Reads: `get_all_samples()`, `get_annotations(sample_id)`, `get_config()`
@@ -57,7 +58,7 @@
 ### Checkpoints
 - Save as fastai export or pickle under `session/`:
   - Classification: `checkpoint.pkl` (fastai Learner export)
-  - Segmentation: `dinov3_linear_classifier_seg.pkl` (pickle of `SGDClassifier`)
+  - Segmentation: `dinov3_linear_classifier_seg.pkl` (pickle with linear Conv head state)
 
 ### Segmentation Masks
 - Filename scheme: write one PNG per binary mask to `session/preds/` named `<sample_id>_<class>.png`.


### PR DESCRIPTION
## Summary
- train the DINOv3 segmentation head with both point and mask supervision via a 1x1 convolutional classifier
- add a configurable `mask_loss_weight` field to the config schema and checkpoint state for balancing mask and point losses
- update documentation to describe the new workflow and mark mask training work as completed

## Testing
- python -m compileall src/ml/dinov3_training.py

------
https://chatgpt.com/codex/tasks/task_e_68d991bdacb0832fa2d6948b0c09bf02