### PR TITLE
Update mask toggle to remove all saved classes

### DIFF
--- a/src/backend/db.py
+++ b/src/backend/db.py
@@ -884,19 +884,30 @@ def delete_annotations_by_type(sample_id, annotation_type):
         return cursor.rowcount
 
 
-def delete_mask_annotation(sample_id, class_name):
-    """Delete mask annotations for a specific class on a sample."""
-    if not class_name:
-        return 0
+def delete_mask_annotation(sample_id, class_name=None):
+    """Delete mask annotations for a sample.
+
+    When ``class_name`` is provided, only annotations for that class are removed.
+    Otherwise all mask annotations for the sample are deleted.
+    """
     with _get_conn() as conn:
         cursor = conn.cursor()
-        cursor.execute(
-            """
-            DELETE FROM annotations
-            WHERE sample_id = ? AND type = 'mask' AND class = ?
-            """,
-            (sample_id, class_name),
-        )
+        if class_name:
+            cursor.execute(
+                """
+                DELETE FROM annotations
+                WHERE sample_id = ? AND type = 'mask' AND class = ?
+                """,
+                (sample_id, class_name),
+            )
+        else:
+            cursor.execute(
+                """
+                DELETE FROM annotations
+                WHERE sample_id = ? AND type = 'mask'
+                """,
+                (sample_id,),
+            )
         return cursor.rowcount
 
 def get_annotation_stats():

--- a/src/frontend/segmentation/js/app.js
+++ b/src/frontend/segmentation/js/app.js
@@ -557,39 +557,24 @@ document.addEventListener('DOMContentLoaded', async () => {
             return false;
         }
         const annotations = Array.isArray(state.currentMaskAnnotations)
-            ? state.currentMaskAnnotations.filter(ann => ann && ann.type === 'mask' && ann.class)
+            ? state.currentMaskAnnotations.filter(ann => ann && ann.type === 'mask')
             : [];
         if (annotations.length === 0) {
             return true;
-        }
-        const annotatedClasses = new Set(annotations.map(ann => ann.class));
-        let targetClass = state.selectedClass;
-        if (!targetClass || !annotatedClasses.has(targetClass)) {
-            if (annotatedClasses.size === 1) {
-                targetClass = Array.from(annotatedClasses)[0];
-            } else {
-                alert('Select a class with a saved mask annotation to remove.');
-                return false;
-            }
-        }
-
-        state.selectedClass = targetClass;
-        if (classesView && typeof classesView.setSelectedClass === 'function') {
-            classesView.setSelectedClass(targetClass);
         }
 
         state.isRemovingMask = true;
         updateMaskAnnotationToggle();
         beginWorkflow();
         try {
-            await api.deleteMaskAnnotation(state.currentSampleId, targetClass);
+            await api.deleteMaskAnnotations(state.currentSampleId);
             const refreshed = await api.loadSample(state.currentSampleId);
             await loadSampleAndContext(refreshed, null);
             return true;
         } catch (err) {
             console.error('Failed to delete mask annotation:', err);
             const message = err && err.message ? err.message : 'Unknown error';
-            alert(`Failed to remove mask annotation: ${message}`);
+            alert(`Failed to remove mask annotations: ${message}`);
             return false;
         } finally {
             state.isRemovingMask = false;

--- a/src/frontend/shared/js/api.js
+++ b/src/frontend/shared/js/api.js
@@ -172,8 +172,8 @@ export class API {
         return data;
     }
 
-    async deleteMaskAnnotation(sampleId, className) {
-        const res = await fetch(`/api/annotations/${sampleId}/mask/${encodeURIComponent(className)}`, {
+    async deleteMaskAnnotations(sampleId) {
+        const res = await fetch(`/api/annotations/${sampleId}/mask`, {
             method: 'DELETE'
         });
         let data = null;
@@ -183,7 +183,7 @@ export class API {
             data = null;
         }
         if (!res.ok) {
-            const err = new Error((data && data.error) ? data.error : 'Failed to delete mask annotation');
+            const err = new Error((data && data.error) ? data.error : 'Failed to delete mask annotations');
             err.status = res.status;
             err.payload = data;
             throw err;

--- a/system_arch/frontend.md
+++ b/system_arch/frontend.md
@@ -52,6 +52,10 @@ The frontend keeps a local config mirror that syncs with the backend on specific
 - Overwrite-by-type reminder: The server replaces all existing annotations of any `type` included in the payload for that sample with exactly those provided. To preserve other types, omit them from the payload. Batch and send the complete list for each included `type`; avoid per-edit writes that could unintentionally overwrite concurrent edits.
 - Delete: Use `DELETE /api/annotations/{id}` to delete all annotations for the current image.
 - Rendering note: Apply class colors and composite overlays; resize masks to match the displayed image dimensions before blending.
+- "Set prediction as mask" checkbox (UI copy: "Add prediction as annotation"):
+  - Availability: Disabled whenever no sample is loaded, a mask prediction map is absent, or a mask save/delete workflow is already running. When a mask annotation already exists, the checkbox is auto-checked; when none exists it is unchecked.
+  - Enabling it requests the backend to persist the currently displayed prediction masks. The frontend gathers every predicted class that includes both `prediction_id` and `prediction_timestamp`, POSTs them to `POST /api/annotations/{sample_id}/accept_mask`, and reloads the sample. If metadata is missing for any class, the checkbox reverts and a warning is shown. A `409 Conflict` triggers an automatic reload of the latest prediction before retrying manually.
+  - Disabling it removes all stored mask annotations for the sample in a single operation. The frontend issues `DELETE /api/annotations/{sample_id}/mask`, regardless of which classes are currently selected, and reloads the sample after a successful response. If the deletion fails, the checkbox returns to the checked state.
 
 ## Status & Feedback
 


### PR DESCRIPTION
## Summary
- update the frontend spec to document that disabling the mask toggle deletes every saved mask for the sample
- change the backend mask deletion endpoint to support removing all saved mask annotations at once
- adjust the segmentation UI to call the new bulk mask deletion API without requiring a class selection

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dba63e11c4832f8e208451823122cf