### PR TITLE
Expose mask loss weight control without point weight

### DIFF
--- a/src/frontend/segmentation/index.html
+++ b/src/frontend/segmentation/index.html
@@ -53,6 +53,7 @@
                                 </select>
                                 <input id="ai-budget" type="number" placeholder="budget" title="Max training iterations / epochs budget">
                                 <input id="ai-resize" type="number" placeholder="resize" title="Image resize (shorter side)">
+                                <input id="ai-mask-weight" type="number" placeholder="mask loss" title="Weight for mask-based loss" step="0.1" min="0">
                                 <div id="ai-status" class="info-display" style="min-height:1.2em;"></div>
                         </div>
                         <button id="prev-btn" class="btn prev-btn">◀ Prev (Ctrl+Left/P)</button>

--- a/src/frontend/segmentation/js/app.js
+++ b/src/frontend/segmentation/js/app.js
@@ -21,7 +21,8 @@ document.addEventListener('DOMContentLoaded', async () => {
             resize: 224,
             available_architectures: [],
             samplePathFilter: '',
-            sampleFilterCount: null
+            sampleFilterCount: null,
+            mask_loss_weight: 1
         },
         configUpdated: false,
         workflowInProgress: false,
@@ -68,7 +69,8 @@ document.addEventListener('DOMContentLoaded', async () => {
             architecture: cfg.architecture || 'small', // Default to 'small' for segmentation
             budget: cfg.budget || 1000,
             resize: cfg.resize || 224,
-            available_architectures: cfg.available_architectures || []
+            available_architectures: cfg.available_architectures || [],
+            mask_loss_weight: typeof cfg.mask_loss_weight === 'number' ? cfg.mask_loss_weight : (state.config.mask_loss_weight ?? 1)
         };
         sampleFilterView.applyServerConfig(cfg);
         if (state.classColors instanceof Map) {

--- a/system_arch/ml.md
+++ b/system_arch/ml.md
@@ -18,7 +18,7 @@
 - `architecture` (str): `resnet18`/`resnet34` for fastai; `small`/`large` for DINOv3
 - `budget` (int): max items to predict per cycle
 - `resize` (int): image resize (fastai: shorter side; DINOv3: padded canvas size)
-- `mask_loss_weight` (float): balance between mask loss and point loss during segmentation training
+- `mask_loss_weight` (float): weighting applied to mask loss during segmentation training
 
 ### Data Exchange
 - Reads: `get_all_samples()`, `get_annotations(sample_id)`, `get_config()`


### PR DESCRIPTION
## Summary
- remove the unused point loss weight plumbing from the configuration, database helpers, and DINOv3 training loop
- document only the mask loss weight setting in the ML architecture notes
- expose a single mask loss weight input in the segmentation UI and shared AI controls

## Testing
- python -m compileall src/backend src/ml

------
https://chatgpt.com/codex/tasks/task_e_68dbae315360832fb6d6c7ef9eb3793a