### PR TITLE
Add validation and regression tests for annotation overwrite semantics

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,77 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from src.backend import db as db_module
+from src.backend import db_init as db_init_module
+
+
+@pytest.fixture
+def test_db(tmp_path, monkeypatch):
+    """Create an isolated database and sample for tests."""
+
+    db_path = tmp_path / "session" / "app.db"
+    session_dir = db_path.parent
+    preds_dir = session_dir / "preds"
+    session_dir.mkdir(parents=True, exist_ok=True)
+
+    # Patch db module globals to point to the temporary database
+    monkeypatch.setattr(db_module, "DB_PATH", str(db_path))
+    monkeypatch.setattr(db_module, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(db_module, "PREDS_DIR", preds_dir)
+
+    # Ensure db_init uses the same database path and lightweight dataset
+    monkeypatch.setattr(db_init_module, "DB_PATH", str(db_path))
+
+    sample_file = tmp_path / "sample.png"
+    sample_file.write_bytes(b"fake-image")
+
+    def fake_build_initial_db_dict():
+        return {
+            "samples": [{"sample_filepath": str(sample_file)}],
+            "annotations": [],
+            "predictions": [],
+        }
+
+    monkeypatch.setattr(db_init_module, "build_initial_db_dict", fake_build_initial_db_dict)
+
+    db_init_module.initialize_database_if_needed(str(db_path))
+
+    with db_module._get_conn() as conn:  # pylint: disable=protected-access
+        sample_id = conn.execute("SELECT id FROM samples").fetchone()[0]
+
+    yield {
+        "db": db_module,
+        "db_init": db_init_module,
+        "db_path": db_path,
+        "session_dir": session_dir,
+        "sample_id": sample_id,
+        "sample_file": sample_file,
+    }
+
+    # Tests operate in isolated temp directories; no explicit cleanup required.
+
+
+@pytest.fixture
+def flask_client(test_db, monkeypatch):
+    """Provide a Flask test client bound to the isolated database."""
+
+    module_name = "src.backend.main"
+    if module_name in sys.modules:
+        del sys.modules[module_name]
+
+    main = importlib.import_module(module_name)
+
+    # Align main's session directories with the temporary environment
+    monkeypatch.setattr(main, "SESSION_DIR", test_db["session_dir"])
+    monkeypatch.setattr(main, "MASKS_DIR", test_db["session_dir"] / "masks")
+    monkeypatch.setattr(main, "PREDS_DIR", test_db["session_dir"] / "preds")
+
+    client = main.app.test_client()
+    return client, main, test_db

--- a/tests/test_annotations_endpoint.py
+++ b/tests/test_annotations_endpoint.py
@@ -1,0 +1,119 @@
+import pytest
+
+
+def _get_claimed(db_module, sample_id):
+    with db_module._get_conn() as conn:  # pylint: disable=protected-access
+        return conn.execute(
+            "SELECT claimed FROM samples WHERE id = ?", (sample_id,)
+        ).fetchone()[0]
+
+
+def test_put_annotations_rejects_unsupported_type(flask_client):
+    client, _, env = flask_client
+    sample_id = env["sample_id"]
+
+    response = client.put(
+        f"/api/annotations/{sample_id}",
+        json=[{"type": "polygon", "class": "dog"}],
+    )
+
+    assert response.status_code == 400
+    assert "Unsupported annotation type" in response.get_json()["error"]
+    assert env["db"].get_annotations(sample_id) == []
+
+
+def test_put_annotations_accepts_skip_without_class(flask_client):
+    client, _, env = flask_client
+    sample_id = env["sample_id"]
+
+    with env["db"]._get_conn() as conn:  # pylint: disable=protected-access
+        conn.execute("UPDATE samples SET claimed = 1 WHERE id = ?", (sample_id,))
+
+    response = client.put(
+        f"/api/annotations/{sample_id}",
+        json=[{"type": "skip", "timestamp": 123}],
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload == {"ok": True, "count": 1}
+
+    annotations = env["db"].get_annotations(sample_id)
+    assert len(annotations) == 1
+    ann = annotations[0]
+    assert ann["type"] == "skip"
+    assert ann.get("class") is None
+    assert ann.get("timestamp") == 123
+
+    assert _get_claimed(env["db"], sample_id) == 0
+
+
+def test_put_annotations_overwrites_by_type(flask_client):
+    client, _, env = flask_client
+    sample_id = env["sample_id"]
+
+    env["db"].upsert_annotation(sample_id, "cat", "label", timestamp=1)
+    env["db"].upsert_annotation(sample_id, "cat", "point", col=0.1, row=0.2, timestamp=1)
+
+    response = client.put(
+        f"/api/annotations/{sample_id}",
+        json=[
+            {"type": "label", "class": "dog", "timestamp": 5},
+            {
+                "type": "point",
+                "class": "dog",
+                "col": 0.3,
+                "row": 0.4,
+                "timestamp": 6,
+            },
+        ],
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload == {"ok": True, "count": 2}
+
+    annotations = env["db"].get_annotations(sample_id)
+    labels = [a for a in annotations if a["type"] == "label"]
+    points = [a for a in annotations if a["type"] == "point"]
+
+    assert len(labels) == 1
+    assert labels[0]["class"] == "dog"
+    assert labels[0]["timestamp"] == 5
+
+    assert len(points) == 1
+    assert points[0]["class"] == "dog"
+    assert points[0]["col01"] == env["db"].to_ppm(0.3)
+    assert points[0]["row01"] == env["db"].to_ppm(0.4)
+    assert points[0]["timestamp"] == 6
+
+
+def test_put_annotations_records_live_accuracy(flask_client):
+    client, _, env = flask_client
+    sample_id = env["sample_id"]
+
+    with env["db"]._get_conn() as conn:  # pylint: disable=protected-access
+        conn.execute(
+            """
+            INSERT INTO predictions (sample_id, class, type, probability, timestamp)
+            VALUES (?, ?, 'label', ?, ?)
+            """,
+            (sample_id, "husky", env["db"].to_ppm(0.8), 10),
+        )
+
+    response = client.put(
+        f"/api/annotations/{sample_id}",
+        json=[{"type": "label", "class": "husky", "timestamp": 15}],
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload == {"ok": True, "count": 1}
+
+    with env["db"]._get_conn() as conn:  # pylint: disable=protected-access
+        rows = conn.execute(
+            "SELECT value FROM curves WHERE curve_name = 'live_accuracy'"
+        ).fetchall()
+
+    assert len(rows) == 1
+    assert rows[0][0] == pytest.approx(1.0)

--- a/tests/test_db_helpers.py
+++ b/tests/test_db_helpers.py
@@ -1,0 +1,64 @@
+import pytest
+
+
+def test_upsert_annotation_requires_mask_path(test_db):
+    db = test_db["db"]
+    sample_id = test_db["sample_id"]
+
+    with pytest.raises(ValueError):
+        db.upsert_annotation(sample_id, "rock", "mask")
+
+
+def test_upsert_annotation_normalizes_coordinates(test_db):
+    db = test_db["db"]
+    sample_id = test_db["sample_id"]
+
+    db.upsert_annotation(
+        sample_id,
+        "granite",
+        "bbox",
+        col=0.1,
+        row=0.2,
+        width=0.3,
+        height=0.4,
+        timestamp=9,
+    )
+
+    annotations = db.get_annotations(sample_id)
+    bbox = [a for a in annotations if a["type"] == "bbox"][0]
+
+    assert bbox["col01"] == db.to_ppm(0.1)
+    assert bbox["row01"] == db.to_ppm(0.2)
+    assert bbox["width01"] == db.to_ppm(0.3)
+    assert bbox["height01"] == db.to_ppm(0.4)
+    assert bbox["timestamp"] == 9
+
+
+def test_delete_annotations_by_type_isolated(test_db):
+    db = test_db["db"]
+    sample_id = test_db["sample_id"]
+
+    db.upsert_annotation(sample_id, "cat", "label", timestamp=1)
+    db.upsert_annotation(sample_id, "dog", "point", col=0.1, row=0.2, timestamp=1)
+
+    deleted = db.delete_annotations_by_type(sample_id, "label")
+    assert deleted == 1
+
+    annotations = db.get_annotations(sample_id)
+    assert all(a["type"] != "label" for a in annotations)
+    assert any(a["type"] == "point" for a in annotations)
+
+
+def test_clear_point_annotations_only_points(test_db):
+    db = test_db["db"]
+    sample_id = test_db["sample_id"]
+
+    db.upsert_annotation(sample_id, "owl", "label", timestamp=2)
+    db.upsert_annotation(sample_id, "sparrow", "point", col=0.3, row=0.5, timestamp=2)
+
+    cleared = db.clear_point_annotations(sample_id)
+    assert cleared == 1
+
+    annotations = db.get_annotations(sample_id)
+    assert any(a["type"] == "label" for a in annotations)
+    assert all(a["type"] != "point" for a in annotations)


### PR DESCRIPTION
## Summary
- validate annotation payloads in the bulk update endpoint, including class and mask_path checks
- keep skip submissions classless while surfacing clear errors for malformed payloads
- add isolated database fixtures and tests that cover overwrite semantics and helper invariants

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbcae12c60832fbc10e92016d9ece9