### PR TITLE
Ensure mask annotation deletions operate per sample/type scope

### DIFF
--- a/src/backend/db.py
+++ b/src/backend/db.py
@@ -885,29 +885,21 @@ def delete_annotations_by_type(sample_id, annotation_type):
 
 
 def delete_mask_annotation(sample_id, class_name=None):
-    """Delete mask annotations for a sample.
+    """Delete all mask annotations for a sample.
 
-    When ``class_name`` is provided, only annotations for that class are removed.
-    Otherwise all mask annotations for the sample are deleted.
+    The optional ``class_name`` argument is accepted for backwards compatibility
+    but ignored so that deletion semantics are always scoped to the
+    ``(sample_id, type='mask')`` pair.
     """
     with _get_conn() as conn:
         cursor = conn.cursor()
-        if class_name:
-            cursor.execute(
-                """
-                DELETE FROM annotations
-                WHERE sample_id = ? AND type = 'mask' AND class = ?
-                """,
-                (sample_id, class_name),
-            )
-        else:
-            cursor.execute(
-                """
-                DELETE FROM annotations
-                WHERE sample_id = ? AND type = 'mask'
-                """,
-                (sample_id,),
-            )
+        cursor.execute(
+            """
+            DELETE FROM annotations
+            WHERE sample_id = ? AND type = 'mask'
+            """,
+            (sample_id,),
+        )
         return cursor.rowcount
 
 def get_annotation_stats():

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -597,17 +597,15 @@ def accept_mask_annotation(sample_id: int):
 def delete_mask_annotation_endpoint(sample_id: int, class_name: str | None):
     """Remove stored mask annotations for a sample.
 
-    When ``class_name`` is provided only that class is removed; otherwise all
-    mask annotations for the sample are deleted.
+    The optional ``class_name`` parameter is accepted for backwards
+    compatibility but ignored; deletions are always performed for the entire
+    ``(sample_id, type='mask')`` scope.
     """
-    class_name = (class_name or "").strip() or None
 
     existing = [
         ann
         for ann in get_annotations(sample_id)
-        if ann.get("type") == "mask"
-        and ann.get("mask_path")
-        and (class_name is None or ann.get("class") == class_name)
+        if ann.get("type") == "mask" and ann.get("mask_path")
     ]
     if not existing:
         # Nothing to delete; return ok to keep frontend logic simple
@@ -619,11 +617,10 @@ def delete_mask_annotation_endpoint(sample_id: int, class_name: str | None):
         prev_path.unlink()
         deleted_files += 1
 
-    deleted_rows = delete_mask_annotation(sample_id, class_name)
+    deleted_rows = delete_mask_annotation(sample_id)
     release_claim_by_id(sample_id)
 
-    scope = "all" if class_name is None else "class"
-    return jsonify({"ok": True, "deleted": deleted_rows, "deleted_files": deleted_files, "scope": scope})
+    return jsonify({"ok": True, "deleted": deleted_rows, "deleted_files": deleted_files, "scope": "all"})
 
 
 @app.get("/api/stats")


### PR DESCRIPTION
## Summary
- update mask deletion endpoint to ignore class-specific scope and always clear annotations by sample/type
- simplify database helper to delete all mask rows for a sample regardless of class argument

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbcbf7c55c832fa5f4c38d18b56d38