### PR TITLE
Clarify classification navigation spec

### DIFF
--- a/system_arch/frontend.md
+++ b/system_arch/frontend.md
@@ -38,6 +38,7 @@ The frontend keeps a local config mirror that syncs with the backend on specific
   1) `PUT /api/annotations/{id}` with `[ { type: "label", class, timestamp } ]`.
   2) Follow the Next workflow sequence above (config push if needed → `GET /api/samples/next` → headers/annotations as applicable → refresh config/stats).
 - Skip: The Skip button (and `S` hotkey) sends `PUT /api/annotations/{id}` with `[ { type: "skip", timestamp } ]`, then runs the same Next workflow. Skip entries clear any existing label for that sample, mark it completed without training impact, and are undoable via the standard Undo flow.
+- Navigation model: The classification tool is task-driven rather than a general image browser. It intentionally omits manual Prev/Next controls and relies on the save/skip/undo actions above to advance or revisit samples so annotators stay focused on labeling instead of ad-hoc browsing.
 - Sample path filter: In both classification and segmentation views, a read-only input becomes editable on focus; on Enter the frontend posts `PUT /api/config` with `{sample_path_filter}`. The backend responds with the updated config (including `sample_path_filter_count`), which the UI renders as "N matches" and then re-locks the input until it's focused again.
  - Strategy parameters:
    - `sequential`, `random`, `minority_frontier`: no additional params.


### PR DESCRIPTION
## Summary
- document that the classification workflow deliberately omits manual Prev/Next controls
- explain that navigation is handled through save/skip/undo actions rather than free browsing

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68dbade7e0a4832f9de77af8e4dcc690