### PR TITLE
Allow hotkeys while non-text inputs are focused

### DIFF
--- a/src/frontend/shared/js/hotkeys.js
+++ b/src/frontend/shared/js/hotkeys.js
@@ -6,6 +6,34 @@
 //   hk.attach();
 // Supports: ctrl/meta/shift/alt modifiers and single keys.
 
+const TEXT_INPUT_TYPES = new Set([
+  'text',
+  'search',
+  'password',
+  'email',
+  'tel',
+  'url',
+  'number'
+]);
+
+export function isTextEntryTarget(target) {
+  if (!target) return false;
+  if (target.isContentEditable) return true;
+  const tagName = (target.tagName || '').toUpperCase();
+  if (tagName === 'TEXTAREA') {
+    return !target.disabled && !target.readOnly;
+  }
+  if (tagName === 'INPUT') {
+    if (target.disabled || target.readOnly) return false;
+    const type = (target.getAttribute('type') || target.type || 'text').toLowerCase();
+    return TEXT_INPUT_TYPES.has(type);
+  }
+  if (tagName === 'SELECT') {
+    return !target.disabled;
+  }
+  return false;
+}
+
 export class Hotkeys {
   constructor(target = document) {
     this.target = target;
@@ -40,7 +68,7 @@ export class Hotkeys {
     return this;
   }
   _onKeydown(e) {
-    if (e.target && (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.isContentEditable)) return;
+    if (isTextEntryTarget(e.target)) return;
     const parts = [];
     if (e.ctrlKey) parts.push('ctrl');
     if (e.metaKey) parts.push('meta');

--- a/src/frontend/shared/views/classesView.js
+++ b/src/frontend/shared/views/classesView.js
@@ -1,3 +1,5 @@
+import { isTextEntryTarget } from '/shared/js/hotkeys.js';
+
 export class ClassesView {
     constructor(container, annotateWorkflow, state) {
         this.container = typeof container === 'string' ? document.querySelector(container) : container;
@@ -13,7 +15,7 @@ export class ClassesView {
         this.isLoading = false;
         this.render();
         document.addEventListener('keydown', async (e) => {
-            if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+            if (isTextEntryTarget(e.target)) return;
             if (this.isLoading) return;
             let idx = -1;
             if (e.key >= '1' && e.key <= '9') {


### PR DESCRIPTION
## Summary
- add a shared helper that detects when a key event originates from a text-entry element
- update the hotkey manager and class selection keyboard handler to ignore only true text inputs
- ensure global shortcuts continue working after interacting with sliders, buttons, and other non-text controls

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbd969b364832fb749b1a09ecf5510